### PR TITLE
Move BTClient into world for apworld bundling

### DIFF
--- a/worlds/banjotooie/BTClient.py
+++ b/worlds/banjotooie/BTClient.py
@@ -335,14 +335,13 @@ async def n64_sync_task(ctx: BanjoTooieContext):
                 continue
 
 
-if __name__ == '__main__':
-
+def main():
     Utils.init_logging("Banjo Tooie Client")
+    parser = get_base_parser()
+    args = parser.parse_args()
 
-    async def main():
+    async def _main():
         multiprocessing.freeze_support()
-        parser = get_base_parser()
-        args = parser.parse_args()
 
         ctx = BanjoTooieContext(args.connect, args.password)
         ctx.server_task = asyncio.create_task(server_loop(ctx), name="Server Loop")
@@ -362,5 +361,9 @@ if __name__ == '__main__':
 
     colorama.init()
 
-    asyncio.run(main())
+    asyncio.run(_main())
     colorama.deinit()
+
+
+if __name__ == '__main__':
+    main()

--- a/worlds/banjotooie/__init__.py
+++ b/worlds/banjotooie/__init__.py
@@ -1,4 +1,5 @@
 import random
+from multiprocessing import Process
 import settings
 import typing
 from jinja2 import Environment, FileSystemLoader
@@ -16,6 +17,16 @@ from .Names import itemName
 from BaseClasses import ItemClassification, Tutorial, Item, Region, MultiWorld
 #from Fill import fill_restrictive
 from ..AutoWorld import World, WebWorld
+from ..LauncherComponents import Component, components, Type
+
+
+def run_client():
+    from worlds.banjotooie.BTClient import main  # lazy import
+    p = Process(target=main)
+    p.start()
+
+
+components.append(Component("Banjo-Tooie Client", func=run_client, component_type=Type.CLIENT))
 
 class BanjoTooieWeb(WebWorld):
     setup = Tutorial("Setup Banjo Tooie",


### PR DESCRIPTION
Moves ``BTClient.py`` into ``worlds/banjootooie`` and adds a Launcher Component to run it via the ArchipelagoLauncher.

This allows the world to bundled into a [apworld](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/apworld%20specification.md) and avoids the need to run this on source for people who want to try this early as they can just drop the ``.apworld`` into thier AP install.
Did a short test with this on my AP 0.4.4 install to confirm I can generate a game with such apworld, the Client can be launched via the Launcher, can connect to the server/bizhawk and at least 1 item is send and received.


