### PR TITLE
Pre alpha

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# 1.8.1-beta
+ - Randomize Worlds World 2 was looking at World 3 jiggy requirements. Fixed so its back to World 2 requirements.
+ - Added Cheato + Honeycomb Calculations to make sure your pages and honeycombs are in sync
+ - King Jingaling is now dead when Skip Jingaling is set (Thanks @Austin)
+ - Load lua on Title screen to skip intro by pressing start (Thanks @Austin)
+ - Hag-1 Phase cutscenes are now skipped (Thanks @Austin)
+
 # 1.8-beta
  - Make Randomize Worlds Compatible with BK Moves (Using Warp Silos)
  - King Jingaling Intro can now be skipped (as an option)

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,21 @@
  - King Jingaling is now dead when Skip Jingaling is set (Thanks @Austin)
  - Load lua on Title screen to skip intro by pressing start (Thanks @Austin)
  - Hag-1 Phase cutscenes are now skipped (Thanks @Austin)
-
+ - Logic Fixes:
+   - Prospector notes: now takes entering from MT into account.
+   - TDL Train Station notes: only the right one needs moves.
+   - GI region access: getting from outside the building to floor 2 or 3 requires climb or moves to make it to the back of the building from the Pipe.
+   - Quality Control jiggy: added Tall Jump if using Mumbo.
+   - Clinker's Cavern Jiggy: added Tall Jump if using Mumbo. Glitched logic requires Climb if doing the jiggy with Breegull Bash.
+   - Sabreman Jiggy: requires Tall Jump.
+   - Mr. Fit Jiggy:
+     - The high jump event can be won with flight for logics other than beginner.
+     - requires Tall Jump for the sack race.
+     - The sprint race can be won with either the bee or turbo trainers for logics other than beginner. Beginner logic needs turbo trainers. Glitched logic can also do it with a clockwork egg.
+   - Pot o' Gold jiggy: requires tall jump if using Mumbo is in logic.
+   - Cheese Wedge jiggy: requires tall jump if using Mumbo is in logic.
+   - Train logic: entering the train requires Flap Flip or Climb. The train is at the ground level in the GI station, so you don't need these moves here.
+   
 # 1.8-beta
  - Make Randomize Worlds Compatible with BK Moves (Using Warp Silos)
  - King Jingaling Intro can now be skipped (as an option)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Archipelago Banjo-Tooie (US-Only) | 1.7.1-Beta
+# Archipelago Banjo-Tooie (US-Only) | 1.8-Beta
 Banjo Tooie for Archipelago 
 
 # Controller Shortcuts with this implementation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Archipelago Banjo-Tooie (US-Only) | 1.8-Beta
+# Archipelago Banjo-Tooie (US-Only) | 1.8.1-Beta
 Banjo Tooie for Archipelago 
 
 # Controller Shortcuts with this implementation

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -15,7 +15,7 @@ local math = require('math')
 require('common')
 
 local SCRIPT_VERSION = 4
-local BT_VERSION = "V1.7.1"
+local BT_VERSION = "V1.8"
 local PLAYER = ""
 local SEED = 0
 local DEATH_LINK = false

--- a/worlds/banjo_tooie/Regions.py
+++ b/worlds/banjo_tooie/Regions.py
@@ -630,7 +630,7 @@ def connect_regions(self):
     region_GM = multiworld.get_region(regionName.GM, player)
     region_GM.add_exits({regionName.GMWSJT, regionName.IOHPL, regionName.CHUFFY, regionName.WW},
     {regionName.GMWSJT: lambda state: rules.can_access_water_storage_jinjo_from_GGM(state),
-     regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state),
+     regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and (rules.hasBKMove(state, itemName.FFLIP) or rules.hasBKMove(state, itemName.CLIMB)),
      regionName.IOHPL: lambda state: rules.GGM_to_PL(state),
      regionName.WW: lambda state: rules.ggm_to_ww(state)})
     
@@ -647,13 +647,13 @@ def connect_regions(self):
     region_WW = multiworld.get_region(regionName.WW, player)
     region_WW.add_exits({regionName.IOHPG, regionName.CHUFFY},
     {regionName.IOHPG: lambda state: rules.ww_jiggy(state),
-     regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWWW, player)})
+     regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWWW, player) and (rules.hasBKMove(state, itemName.FFLIP) or rules.hasBKMove(state, itemName.CLIMB))})
 
     region_IOHCT = multiworld.get_region(regionName.IOHCT, player)
     region_IOHCT.add_exits({regionName.IOHCT_HFP_ENTRANCE, regionName.HP, regionName.JR, regionName.CHUFFY},
         {regionName.HP:lambda state: rules.hfp_jiggy(state),
          regionName.JR: lambda state: rules.jrl_jiggy(state),
-         regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWIH, player)})
+         regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWIH, player) and (rules.hasBKMove(state, itemName.FFLIP) or rules.hasBKMove(state, itemName.CLIMB))})
   
     region_JR = multiworld.get_region(regionName.JR, player)
     region_JR.add_exits({regionName.JRU, regionName.IOHCT},
@@ -673,7 +673,7 @@ def connect_regions(self):
                         {regionName.IOHCT_HFP_ENTRANCE: lambda state: rules.HFP_to_CTHFP(state),
                          regionName.MT: lambda state: rules.HFP_to_MT(state),
                          regionName.JR: lambda state: rules.HFP_to_JRL(state),
-                         regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWHP1, player)})
+                         regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWHP1, player) and (rules.hasBKMove(state, itemName.FFLIP) or rules.hasBKMove(state, itemName.CLIMB))})
     region_IOHWL = multiworld.get_region(regionName.IOHWL, player)
     region_IOHWL.add_exits({regionName.IOHPGU, regionName.IOHQM, regionName.TL, regionName.CC},
                         {regionName.IOHPGU: lambda state: rules.WL_to_PGU(state),
@@ -684,7 +684,7 @@ def connect_regions(self):
     region_TL = multiworld.get_region(regionName.TL, player)
     region_TL.add_exits({regionName.TL_HATCH, regionName.WW, regionName.CHUFFY, regionName.IOHWL},
                         {regionName.WW: lambda state: rules.TDL_to_WW(state),
-                         regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWTD, player),
+                         regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWTD, player) and (rules.hasBKMove(state, itemName.FFLIP) or rules.hasBKMove(state, itemName.CLIMB)),
                          regionName.IOHWL: lambda state: rules.TDL_to_IOHWL(state),
                          regionName.TL_HATCH: lambda state: rules.longJump(state),
                          })
@@ -707,7 +707,7 @@ def connect_regions(self):
                         {regionName.GIO: lambda state: state.has(itemName.SPLITUP, self.player),
                          regionName.GI2: lambda state: rules.can_access_gi_fl1_2fl2(state),
                          regionName.GI3ALL: lambda state: rules.F1_to_F3(state),
-                         regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWGI, player)})
+                         regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and state.has(itemName.TRAINSWGI, player)}) # For this one, the train loading zone is at the ground level.
     
     region_GI2 = multiworld.get_region(regionName.GI2, player)
     region_GI2.add_exits({regionName.GIO, regionName.GI1, regionName.GI3ALL},

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -588,12 +588,8 @@ class BanjoTooieRules:
             locationName.NOTEJRL14:  lambda state: self.notes_jolly(state),
             locationName.NOTEJRL15:  lambda state: self.notes_jolly(state),
             locationName.NOTEJRL16:  lambda state: self.notes_jolly(state),
-
-            # TODO: I don't know which of the 3 is the right one.
+            
             locationName.NOTETDL1:  lambda state: self.canDoSmallElevation(state),
-            locationName.NOTETDL2:  lambda state: self.canDoSmallElevation(state),
-            locationName.NOTETDL3:  lambda state: self.canDoSmallElevation(state),
-
             locationName.NOTETDL10:  lambda state: self.longJump(state) or state.has(itemName.SPRINGB, self.player) or self.TDLFlightPad(state),
             locationName.NOTETDL11:  lambda state: self.longJump(state) or state.has(itemName.SPRINGB, self.player) or self.TDLFlightPad(state),
             locationName.NOTETDL12:  lambda state: self.longJump(state) or state.has(itemName.SPRINGB, self.player) or self.TDLFlightPad(state),
@@ -1431,21 +1427,16 @@ class BanjoTooieRules:
         if self.world.options.logic_type == 0: # beginner
             logic = self.mumboGI(state) and state.has(itemName.GEGGS, self.player) and \
                     state.has(itemName.EGGAIM, self.player) and \
-                    self.can_use_battery(state) and self.check_humba_magic(state, itemName.HUMBAGI)
+                    self.can_use_battery(state) and self.check_humba_magic(state, itemName.HUMBAGI) and self.hasBKMove(state, itemName.TJUMP)
         elif self.world.options.logic_type == 1: # normal
             logic = self.mumboGI(state) and self.canShootEggs(state, itemName.GEGGS) and \
                     ((state.has(itemName.EGGAIM, self.player) and (self.check_humba_magic(state, itemName.HUMBAGI)) or \
-                    self.check_solo_moves(state, itemName.LSPRING))) and self.can_use_battery(state)
+                    self.check_solo_moves(state, itemName.LSPRING))) and self.can_use_battery(state) and self.hasBKMove(state, itemName.TJUMP)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.mumboGI(state) and self.canShootEggs(state, itemName.GEGGS) and \
-                    ((state.has(itemName.EGGAIM, self.player) and (self.check_humba_magic(state, itemName.HUMBAGI)) or \
-                    self.check_solo_moves(state, itemName.LSPRING) or self.hasBKMove(state, itemName.TJUMP))) and self.can_use_battery(state)
+            logic = self.mumboGI(state) and self.canShootEggs(state, itemName.GEGGS) and self.can_use_battery(state) and self.hasBKMove(state, itemName.TJUMP)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.mumboGI(state) and self.canShootEggs(state, itemName.GEGGS) and \
-                    ((state.has(itemName.EGGAIM, self.player) and (self.check_humba_magic(state, itemName.HUMBAGI)) or \
-                    self.check_solo_moves(state, itemName.LSPRING) or self.hasBKMove(state, itemName.TJUMP))) and self.can_use_battery(state))\
-                    or (self.canShootEggs(state, itemName.GEGGS) and state.has(itemName.CEGGS, self.player) and (self.springPad(state)) or \
-                        self.hasBKMove(state, itemName.FFLIP))
+            logic = (self.mumboGI(state) and self.canShootEggs(state, itemName.GEGGS) and self.can_use_battery(state) and self.hasBKMove(state, itemName.TJUMP))\
+                    or (self.canShootEggs(state, itemName.GEGGS) and state.has(itemName.CEGGS, self.player) and (self.springPad(state) or self.hasBKMove(state, itemName.FFLIP)))
         return logic
     
     def jiggy_guarded(self, state: CollectionState) -> bool:
@@ -1525,16 +1516,16 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = self.check_mumbo_magic(state, itemName.MUMBOHP) and self.canShootEggs(state, itemName.FEGGS) and \
-                    self.check_solo_moves(state, itemName.TAXPACK)
+                    self.check_solo_moves(state, itemName.TAXPACK) and self.hasBKMove(state, itemName.TJUMP)
         elif self.world.options.logic_type == 1: # normal
             logic = self.check_mumbo_magic(state, itemName.MUMBOHP) and self.has_fire(state) and \
-                    self.check_solo_moves(state, itemName.TAXPACK)
+                    self.check_solo_moves(state, itemName.TAXPACK) and self.hasBKMove(state, itemName.TJUMP)
         elif self.world.options.logic_type == 2: # advanced
             logic = self.check_mumbo_magic(state, itemName.MUMBOHP) and self.has_fire(state) and \
-                    self.check_solo_moves(state, itemName.TAXPACK)
+                    self.check_solo_moves(state, itemName.TAXPACK) and self.hasBKMove(state, itemName.TJUMP)
         elif self.world.options.logic_type == 3: # glitched
             logic = self.check_mumbo_magic(state, itemName.MUMBOHP) and self.has_fire(state) and \
-                    self.check_solo_moves(state, itemName.TAXPACK)
+                    self.check_solo_moves(state, itemName.TAXPACK) and self.hasBKMove(state, itemName.TJUMP)
         return logic
 
     def jiggy_boggy(self, state: CollectionState) -> bool:
@@ -1668,20 +1659,24 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = self.cclStarterPack(state) and state.has(itemName.SPRINGB, self.player) and self.check_solo_moves(state, itemName.SAPACK) and \
-                    self.grow_beanstalk(state) and self.can_use_floatus(state) and self.hasBKMove(state, itemName.CLIMB)
+                    self.grow_beanstalk(state) and self.can_use_floatus(state) and self.hasBKMove(state, itemName.CLIMB)\
+                    and self.hasBKMove(state, itemName.TTRAIN)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.cclStarterPack(state) and state.has(itemName.SPRINGB, self.player) and self.check_solo_moves(state, itemName.SAPACK) and \
-                    self.grow_beanstalk(state) and self.can_use_floatus(state) and self.hasBKMove(state, itemName.CLIMB)
+            logic = self.cclStarterPack(state) and (state.has(itemName.SPRINGB, self.player) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
+                    self.grow_beanstalk(state) and self.can_use_floatus(state) and self.hasBKMove(state, itemName.CLIMB)\
+                    and (self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.HUMBACC, self.player))
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.cclStarterPack(state) and state.has(itemName.SPRINGB, self.player) and self.check_solo_moves(state, itemName.SAPACK) and \
+            logic = self.cclStarterPack(state) and (state.has(itemName.SPRINGB, self.player) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
                     self.grow_beanstalk(state) and \
-                    (self.can_use_floatus(state) or (self.check_solo_moves(state, itemName.PACKWH) and self.hasBKMove(state, itemName.TJUMP)))\
-                    and self.hasBKMove(state, itemName.CLIMB)
+                    (self.can_use_floatus(state) or self.check_solo_moves(state, itemName.PACKWH))\
+                    and self.hasBKMove(state, itemName.CLIMB)\
+                    and (self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.HUMBACC, self.player))
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.cclStarterPack(state) and state.has(itemName.SPRINGB, self.player) and self.check_solo_moves(state, itemName.SAPACK) and \
+            logic = self.cclStarterPack(state) and (state.has(itemName.SPRINGB, self.player) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
                     self.grow_beanstalk(state) and \
-                    (self.can_use_floatus(state) or (self.check_solo_moves(state, itemName.PACKWH) and self.hasBKMove(state, itemName.TJUMP)))\
-                        and self.hasBKMove(state, itemName.CLIMB)
+                    (self.can_use_floatus(state) or self.check_solo_moves(state, itemName.PACKWH))\
+                    and self.hasBKMove(state, itemName.CLIMB)\
+                    and (self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.HUMBACC, self.player) or self.canShootEggs(state, itemName.CEGGS))
         return logic
     
     def jiggy_gold_pot(self, state: CollectionState) -> bool:
@@ -3095,7 +3090,6 @@ class BanjoTooieRules:
             logic = self.billDrill(state) or self.has_explosives(state)
         return logic
     
-    # TODO: may need to add leg spring for glitched
     def doubloon_water(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
@@ -3197,13 +3191,13 @@ class BanjoTooieRules:
     def placeholder_prospector_note(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.GGMSlope(state) or self.hasBKMove(state, itemName.FFLIP)
+            logic = self.GGMSlope(state) or self.hasBKMove(state, itemName.FFLIP) or (self.mt_jiggy(state) and self.dilberta_free(state))
         elif self.world.options.logic_type == 1: # normal
-            logic = self.GGMSlope(state) or self.hasBKMove(state, itemName.FFLIP)
+            logic = self.GGMSlope(state) or self.hasBKMove(state, itemName.FFLIP) or (self.mt_jiggy(state) and self.dilberta_free(state))
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.GGMSlope(state) or self.hasBKMove(state, itemName.FFLIP) or self.clockwork_shot(state)
+            logic = self.GGMSlope(state) or self.hasBKMove(state, itemName.FFLIP) or self.clockwork_shot(state) or (self.mt_jiggy(state) and self.dilberta_free(state))
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.GGMSlope(state) or self.hasBKMove(state, itemName.FFLIP) or self.clockwork_shot(state)
+            logic = self.GGMSlope(state) or self.hasBKMove(state, itemName.FFLIP) or self.clockwork_shot(state) or (self.mt_jiggy(state) and self.dilberta_free(state))
         return logic
     
     def notes_gm_mumbo(self, state: CollectionState) -> bool:
@@ -3541,12 +3535,11 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 3: # glitched
             return self.humbaGGM(state) or self.canShootEggs(state, itemName.CEGGS)
 
-    # TODO: make logic for entering the train that makes sense, based on the world.
     def can_beat_king_coal(self, state) -> bool:
         if self.world.options.randomize_chuffy == False:
-            return self.mumboGGM(state) and self.can_access_GM(state) and self.canDoSmallElevation(state) and self.hasBKMove(state, itemName.CLIMB)
+            return self.mumboGGM(state) and self.can_access_GM(state) and (self.hasBKMove(state, itemName.FFLIP) or self.hasBKMove(state, itemName.CLIMB)) and self.hasGroundAttack(state)
         else:
-            return state.has(itemName.CHUFFY, self.player) and self.canDoSmallElevation(state) and self.hasBKMove(state, itemName.CLIMB)
+            return state.has(itemName.CHUFFY, self.player) and self.hasGroundAttack(state)
 
 
     #deprecated but might be useful for ticket randomization
@@ -3570,8 +3563,8 @@ class BanjoTooieRules:
             return (self.longJumpToGripGrab(state) and self.hasBKMove(state, itemName.FFLIP) and self.hasBKMove(state, itemName.CLIMB) and (self.has_explosives(state) or self.hasBKMove(state, itemName.BBARGE)))\
                 or (state.has(itemName.EGGAIM, self.player) and state.has(itemName.GEGGS, self.player))\
                 or (self.has_explosives(state) and self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE))\
-                or (self.can_access_GM(state) and self.canDoSmallElevation(state) and self.canShootEggs(state, itemName.CEGGS)) # You can shoot a clockwork through the door from GGM.
-                # TODO: do better on this line^
+                or (self.can_access_GM(state) and self.humbaGGM(state) and self.canDoSmallElevation(state) and self.canShootEggs(state, itemName.CEGGS)) # You can shoot a clockwork through the door from GGM.
+
 
     def can_reach_saucer(self, state: CollectionState) -> bool:
         return (self.longJumpToGripGrab(state) and self.hasBKMove(state, itemName.FFLIP) and self.hasBKMove(state, itemName.CLIMB)) or (self.can_access_GM(state) and self.canDoSmallElevation(state))
@@ -3641,13 +3634,14 @@ class BanjoTooieRules:
     def jiggy_clinkers(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.mumboGI(state) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
+            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.mumboGI(state) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
+            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.mumboGI(state) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
+            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.mumboGI(state) or (self.breegullBash(state)))\
+            logic = ((self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP))\
+                     or ((self.breegullBash(state) or (state.has(itemName.GEGGS, self.player) and state.has(itemName.EGGAIM, self.player))) and self.hasBKMove(state, itemName.CLIMB)))\
                   and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
         return logic
 
@@ -4084,7 +4078,7 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 2: # advanced
             logic = False
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.canShootEggs(state, itemName.CEGGS)
+            logic = self.canShootEggs(state, itemName.CEGGS) and (self.hasBKMove(state, itemName.CLIMB) or self.extremelyLongJump(state))
         return logic
     
     def outside_gi_to_floor3(self, state: CollectionState) -> bool:
@@ -4092,14 +4086,13 @@ class BanjoTooieRules:
         if self.world.options.logic_type == 0: # beginner
             logic = False
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.TTROT)\
-                     and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT))
+            logic = state.has(itemName.CLAWBTS, self.player) and self.veryLongJump(state) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.TTROT)\
-                     and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT))
+            logic = state.has(itemName.CLAWBTS, self.player) and self.veryLongJump(state) and\
+                    (self.hasBKMove(state, itemName.CLIMB) or self.extremelyLongJump(state))
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.TTROT)\
-                     and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT))
+            logic = state.has(itemName.CLAWBTS, self.player) and self.veryLongJump(state) and\
+                    (self.hasBKMove(state, itemName.CLIMB) or self.extremelyLongJump(state))
         return logic
 
     def can_access_gi_outside_from_inside(self, state: CollectionState) -> bool:
@@ -4664,7 +4657,6 @@ class BanjoTooieRules:
                  or (self.hasBKMove(state, itemName.CLIMB) and self.veryLongJump(state) and self.hasBKMove(state, itemName.FFLIP))\
                 or (self.clockwork_shot(state) and self.hasBKMove(state, itemName.CLIMB)))
         elif self.world.options.logic_type == 3: # glitched
-            # TODO: check if can shoot through van door
             logic = state.has(itemName.HUMBAWW, self.player) and \
                 ((self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player)) \
                  or (self.hasBKMove(state, itemName.CLIMB) and self.veryLongJump(state) and self.hasBKMove(state, itemName.FFLIP))\
@@ -4713,7 +4705,7 @@ class BanjoTooieRules:
         return logic
     
     def mumboCCL(self, state: CollectionState) -> bool:
-        return self.cclStarterPack(state) and state.has(itemName.MUMBOCC, self.player)
+        return self.hasBKMove(state, itemName.TJUMP) and state.has(itemName.MUMBOCC, self.player)
     
     def humbaTDL(self, state: CollectionState) -> bool:
         logic = True

--- a/worlds/banjo_tooie/WorldOrder.py
+++ b/worlds/banjo_tooie/WorldOrder.py
@@ -89,11 +89,11 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
                 second_level = random.choice(second_level_selection)
                 i = i+1
                 if world.options.game_length.value == 1: # Normal
-                    world.randomize_worlds.update({second_level: 8})
+                    world.randomize_worlds.update({second_level: 4})
                 elif world.options.game_length.value == 0: # Quick
-                    world.randomize_worlds.update({second_level: 6})
+                    world.randomize_worlds.update({second_level: 3})
                 elif world.options.game_length.value == 2: # Long
-                    world.randomize_worlds.update({second_level: 16})
+                    world.randomize_worlds.update({second_level: 8})
                 else: # Custom
                     world.randomize_worlds.update({second_level: world.options.world_2.value})
                 world.world_sphere_2.remove(second_level)

--- a/worlds/banjo_tooie/docs/en_Banjo-Tooie.md
+++ b/worlds/banjo_tooie/docs/en_Banjo-Tooie.md
@@ -10,7 +10,7 @@ config file.
 Randomize Items, skip certain cutscenes and dialogs, Skippable Tower of Tragedy, Shorten Long mini-games,
 Pause Menu will display total items collected in your game + Multi-world, and Pause Menu -> Totals acts like a in-game Tracker for check locations.
 
-## What items and locations get shuffled?
+## What items and locations can get shuffled?
 
 - Jiggies
 - Treble Clefs
@@ -20,6 +20,11 @@ Pause Menu will display total items collected in your game + Multi-world, and Pa
 - Glowbos
 - Mega Glowbo
 - Doubloons
+- Ice Key
+- Mystery Eggs
+- Banjo Kazooie Moves
+- Notes
+- Double Air + Fast Swimming
 
 ## When the player receives an item, what happens?
 

--- a/yaml-template/template.yaml
+++ b/yaml-template/template.yaml
@@ -63,11 +63,12 @@ Banjo-Tooie:
 
   logic_type: 0                # 0: Beginner, 1: Normal, 2: Advanced, 3: glitched
   jingaling_jiggy: 'true'      # True: Always get Jiggy from Jingaling; recommended when playing Multiworld.
+  skip_jingaling: 'true'       # Get Jingaling's reward early and head straight to Bottle's home.
   skip_tower_of_tragedy: 1     # 0: no skip, 1: skip completely, 2: play 3rd round only
   speed_up_minigames: 'true'   # skip to round 3 of kickball, dodgems
   skip_puzzles: 'true'
   skip_klungo: 'true'          # Skips Klungo 1 & 2
-  skip_jingaling: 'true'
+
 
   # Victory Conditions
   #   0: HAG-1


### PR DESCRIPTION
# 1.8.1-beta
 - Randomize Worlds World 2 was looking at World 3 jiggy requirements. Fixed so its back to World 2 requirements.
 - Added Cheato + Honeycomb Calculations to make sure your pages and honeycombs are in sync
 - King Jingaling is now dead when Skip Jingaling is set (Thanks @Austin)
 - Load lua on Title screen to skip intro by pressing start (Thanks @Austin)
 - Hag-1 Phase cutscenes are now skipped (Thanks @Austin)
 - Logic Fixes:
   - Prospector notes: now takes entering from MT into account.
   - TDL Train Station notes: only the right one needs moves.
   - GI region access: getting from outside the building to floor 2 or 3 requires climb or moves to make it to the back of the building from the Pipe.
   - Quality Control jiggy: added Tall Jump if using Mumbo.
   - Clinker's Cavern Jiggy: added Tall Jump if using Mumbo. Glitched logic requires Climb if doing the jiggy with Breegull Bash.
   - Sabreman Jiggy: requires Tall Jump.
   - Mr. Fit Jiggy:
     - The high jump event can be won with flight for logics other than beginner.
     - requires Tall Jump for the sack race.
     - The sprint race can be won with either the bee or turbo trainers for logics other than beginner. Beginner logic needs turbo trainers. Glitched logic can also do it with a clockwork egg.
   - Pot o' Gold jiggy: requires tall jump if using Mumbo is in logic.
   - Cheese Wedge jiggy: requires tall jump if using Mumbo is in logic.
   - Train logic: entering the train requires Flap Flip or Climb. The train is at the ground level in the GI station, so you don't need these moves here.