### PR TITLE
Pre alpha

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,20 @@
+# 2.1-beta
+ - 3 Additional BK Moves to the pool:
+    - Beak Buster
+    - Turbo Trainers
+    - Air Rat-a-tat Rap
+    - Blue Eggs (sort of.. read below)
+ - 3 additional check locations: GGM Crushing Shed Jiggy Chunks
+ - Generation no longer fails when a world cost is set at over 70 jiggies.
+ - Deathlink is now implemented.
+ - Optional Progressive Beak Buster -> Bill Drill
+ - New option for Eggs:
+   - Start with Blue Eggs (what we are used to)
+   - Randomized Starting Egg
+   - Progressive Eggs (Blue -> Fire -> Grenade -> Ice -> Clockwork)
+ - Logic fixes:
+   - Fix Prospector Boulder
+
 # 2.0-beta
  - 3 Additional BK Moves to the pool:
     - Beak Buster

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,11 @@
     - Roll
     - Ground Rat-a-tat Rap
     - Air Rat-a-tat Rap
+ - New Options:
+   - Progressive Shoes (Stilt Stride -> Turbo Trainers -> Spring Boots -> Claw Climbers)
+   - Progressive Water Training (Dive -> Double Air -> Faster Swimming)
+   - Progressive Bash Attack (Ground Rat-a-tat Rap -> Breegull Bash)
+ - 60 FPS Toggle - Hit L + Start in-game to increase the in-game clock to run 60 FPS instead of 30 (may affect CPU performance)
  - Logic fixes:
    - Fix Prospector Boulder
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,17 +1,19 @@
 # 2.1-beta
- - 3 Additional BK Moves to the pool:
-    - Beak Buster
-    - Turbo Trainers
+ - The Last 4 BK Moves are in the pool:
+    - Ground Rat-a-tat Rap
+    - Stilt Stride
+    - Beak Barge
+    - Beak Bomb
+ - 3 additional check locations:
+    - Goggles (Amaze-O-Gaze)
+    - Big Al (Burger Stall)
+    - Salty Joe (Fries Stall)
+ - When you start a seed with BK Moves randomized, you start with 1 random move:
+    - Egg Shoot
+    - Beak Barge
+    - Roll
+    - Ground Rat-a-tat Rap
     - Air Rat-a-tat Rap
-    - Blue Eggs (sort of.. read below)
- - 3 additional check locations: GGM Crushing Shed Jiggy Chunks
- - Generation no longer fails when a world cost is set at over 70 jiggies.
- - Deathlink is now implemented.
- - Optional Progressive Beak Buster -> Bill Drill
- - New option for Eggs:
-   - Start with Blue Eggs (what we are used to)
-   - Randomized Starting Egg
-   - Progressive Eggs (Blue -> Fire -> Grenade -> Ice -> Clockwork)
  - Logic fixes:
    - Fix Prospector Boulder
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,9 +6,11 @@
     - Beak Bomb
  - 3 additional check locations:
     - Goggles (Amaze-O-Gaze)
-    - Big Al (Burger Stall)
-    - Salty Joe (Fries Stall)
- - When you start a seed with BK Moves randomized, you start with a random attack to be able to defeat Klungo:
+    - Scrut (Scrotty's Kid)
+    - Scrat (Scrotty's Kid)
+    - Scrit (Scrotty's Kid)
+ - New item in the Pool: Amaze-O-Gaze
+ - When you start a seed with BK Moves randomized, you start with 1 random attack:
     - Egg Shoot
     - Egg aim
     - Beak Barge
@@ -29,6 +31,7 @@
    - GGM Jail Jinjo: Shooting a clockwork through the wall is now part of glitched logic.
    - Scrotty Jiggy: The 3 kids have been separated into their own logic, which may have some slight side-effects.
    - Egg barges (glitch): can now be only done with blue, fire and ice eggs.
+   - Saucer of Perl logic modified to also require Amaze-O-Gaze for certain tricks
 
 # 2.0-beta
  - 3 Additional BK Moves to the pool:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Banjo Tooie for Archipelago
 - Beak Buster
 - Turbo Trainers
 - Blue Eggs
+- Ground Rat-a-tat Rap
+- Stilt Stride
+- Beak Barge
+- Beak Bomb
 
 # Possible Win Conditions
 - Beating Hag-1 (Vanilla)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Archipelago Banjo-Tooie (US-Only) | 2.0-Beta
+# Archipelago Banjo-Tooie (US-Only) | 2.1-Beta
 Banjo Tooie for Archipelago 
 
 # Controller Shortcuts with this implementation

--- a/README.md
+++ b/README.md
@@ -14,28 +14,28 @@ Banjo Tooie for Archipelago
 
 # Current implementation
 - Death Link
-- Jiggies are scattered throughout Archipelago games
-- Empty Honeycombs are scattered throughout Archipelago games (YAML Option) 
+- Jiggies
+- Empty Honeycombs (YAML Option) 
 - Skippable Tower of Tragedy
-- Victory condition when you defeat HAG1
-- Cheato Pages are scattered throughout Archipelago games
-- Glowbos are scattered throughout Archipelago games and activates magic automatically
-- Banjo Advanced Jamjar Moves are scattered throughout Archipelago games
+- Cheato Pages (YAML Option)
+- Glowbos activates magic automatically (YAML Option)
+- Banjo Advanced Jamjar Moves (YAML Option)
 - Auto skip certian dialogs and cutscenes
-- Doubloons are scattered throughout Archipelago games
-- Treble Clef are scattered throughout Archipelago games
-- Train Station are scattered throughout Archipelago games
-- Chuffy as an optional AP Item
-- Jinjos are scattered throughout Archipelago games 
-- Notes are scattered throughout Archipelago games
+- Doubloons (YAML Option)
+- Treble Clef (YAML Option)
+- Train Station (YAML Option)
+- Chuffy as an AP Item (YAML Option) 
+- Jinjos (YAML Option)
+- Notes (YAML Option)
 - Skip Jiggywiggy puzzles to open levels
 - Option for worlds to open in random order. (requires certian amount of items randomized and puzzle skip)
 - Alternate Goals
 - Prison code is always set to: <b>Sun, Moon, Star, Moon, Sun</b>
 - Cheato Rewards as an option (awards an additional randomized item)
 - Honey B Rewards as an option (awards an additional randomized item)
-- Randomize Original Banjo-Kazooie Moves
-- Change how Eggs works
+- Randomize Original Banjo-Kazooie Moves (YAML Option)
+- Change how Eggs works (YAML Option)
+- Progressive Ability Upgrades
 
 # Implemented Banjo-Kazooie Moves in Archipelago
 - Dive

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -6904,6 +6904,32 @@ function processAGIItem(item_list)
                     BTCONSUMEOBJ:changeConsumable("CWK EGGS")
                     BTCONSUMEOBJ:setConsumable(10)
                 end
+            elseif(memlocation == 1230830) -- Progressive Shoes
+            then
+                local progressive_count = 0
+                for ap_id, memloc in pairs(receive_map)
+                do
+                    if memloc == "1230830"
+                    then
+                        progressive_count = progressive_count + 1
+                    end
+                end
+                if progressive_count == 0 then
+                    BTRAMOBJ:setFlag(0x1A, 3, "Stilt Stride")
+                end
+                if progressive_count == 1 then
+                    BTRAMOBJ:setFlag(0x1A, 6, "Turbo Trainers")
+                end
+                if progressive_count == 2 then
+                    local location = "1230768"
+                    AGI_MOVES[location] = true
+                    set_AGI_MOVES_checks()
+                end
+                if progressive_count == 3 then
+                    local location = "1230773"
+                    AGI_MOVES[location] = true
+                    set_AGI_MOVES_checks()
+                end
             end
             receive_map[tostring(ap_id)] = tostring(memlocation)
             savingAGI();

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -6987,7 +6987,7 @@ function process_block(block)
     then
         return
     end
-    if next(block['items']) ~= nil
+    if next(block['items']) ~= nil and INIT_COMPLETE
     then
         processAGIItem(block['items'])
     end
@@ -7028,6 +7028,7 @@ function SendToBTClient()
     retTable["jiggy_chunks"] = JIGGY_CHUNKS;
     retTable["goggles"] = GOGGLES;
     retTable["food_stalls"] = FOOD_STALLS;
+    retTable["banjo_map"] = CURRENT_MAP;
     if GAME_LOADED == false
     then
         retTable["sync_ready"] = "false"

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -15,7 +15,7 @@ local math = require('math')
 require('common')
 
 local SCRIPT_VERSION = 4
-local BT_VERSION = "V2.0"
+local BT_VERSION = "V2.1"
 local PLAYER = ""
 local SEED = 0
 local DEATH_LINK = false

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -18,7 +18,6 @@ local SCRIPT_VERSION = 4
 local BT_VERSION = "V2.1"
 local PLAYER = ""
 local SEED = 0
-local DEATH_LINK = false
 
 local BT_SOCK = nil
 
@@ -6930,6 +6929,44 @@ function processAGIItem(item_list)
                     AGI_MOVES[location] = true
                     set_AGI_MOVES_checks()
                 end
+            elseif(memlocation == 1230831) -- Progressive Water Training
+            then
+                local progressive_count = 0
+                for ap_id, memloc in pairs(receive_map)
+                do
+                    if memloc == "1230831"
+                    then
+                        progressive_count = progressive_count + 1
+                    end
+                end
+                if progressive_count == 0 then
+                    BTRAMOBJ:setFlag(0x1A, 4, "Dive")
+                end
+                if progressive_count == 1 then
+                    BTRAMOBJ:setFlag(0x32, 7, "Double Air")
+                    DOUBLE_AIR = true
+                end
+                if progressive_count == 2 then
+                    BTRAMOBJ:setFlag(0x1E, 5, "Fast Swimming")
+                    FAST_SWIM = true
+                end
+            elseif(memlocation == 1230832) -- Progressive Bash Attack
+            then
+                local progressive_count = 0
+                for ap_id, memloc in pairs(receive_map)
+                do
+                    if memloc == "1230832"
+                    then
+                        progressive_count = progressive_count + 1
+                    end
+                end
+                if progressive_count == 0 then
+                    BTRAMOBJ:setFlag(0x19, 1, "GRAT")
+                end
+                if progressive_count == 1 then
+                    AGI_MYSTERY["1230800"] = true
+                    obtain_breegull_bash()
+                end
             end
             receive_map[tostring(ap_id)] = tostring(memlocation)
             savingAGI();
@@ -7354,12 +7391,14 @@ function DPadStats()
         end
 		
 		if check_controls ~= nil and check_controls['P1 DPad D'] == true and check_controls['P1 L'] == true and REGEN == false
+        and DEATH_LINK == false
         then
            BTRAMOBJ:setFlag(0xA1, 7, "Automatic Energy Regain")
            REGEN = true
            print(" ")
            print("Automatic Energy Regain Enabled")
         elseif check_controls ~= nil and check_controls['P1 DPad D'] == true and check_controls['P1 L'] == true and REGEN == true
+        and DEATH_LINK == false
         then
             BTRAMOBJ:clearFlag(0xA1, 7)
             REGEN = false

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -60,6 +60,7 @@ local SUPERBANJO = false;
 local REGEN = false;
 local TEXT_TIMER = 2;
 local TEXT_START = false;
+local FPS = false
 
 local ENABLE_AP_HONEYCOMB = false;
 local ENABLE_AP_PAGES = false;
@@ -7279,6 +7280,26 @@ function DPadStats()
             REGEN = false
             print(" ")
             print("Automatic Energy Regain Disabled")
+        end
+
+        if check_controls ~= nil and check_controls['P1 L'] == true and check_controls['P1 R'] == true and FPS == false
+        then
+            mainmemory.write_u8(0x07913F, 1)
+        elseif check_controls ~= nil and check_controls['P1 L'] == true and check_controls['P1 R'] == true and FPS == true
+        then
+            mainmemory.write_u8(0x07913F, 2)
+        end
+
+        if check_controls ~= nil and check_controls['P1 L'] == true and check_controls['P1 R'] == true and FPS == false
+        then
+            mainmemory.write_u8(0x07913F, 1)
+            print("Smooth Banjo Enabled")
+            FPS = true
+        elseif check_controls ~= nil and check_controls['P1 L'] == true and check_controls['P1 R'] == true and FPS == true
+        then
+            mainmemory.write_u8(0x07913F, 2)
+            print("Smooth Banjo Disabled")
+            FPS = false
         end
     end
 end

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -5664,6 +5664,7 @@ end
 
 function killBT()
     if KILL_BANJO == true then
+        CHECK_DEATH = true -- Avoid Death loops
         BTMODELOBJ:changeName("Player", false)
         local player = BTMODELOBJ:checkModel();
         if player == false
@@ -5683,8 +5684,11 @@ function killBT()
                     kill_animation = 0x02 -- Explode 
                 end 
                 mainmemory.write_u8(0x12b161, kill_animation)--max air and suffocation flag?
-                KILL_BANJO = false
-                CHECK_DEATH = true
+                local death_flg = mainmemory.read_u8(0x1354F9)
+                if death_flg == 1
+                then
+                    KILL_BANJO = false
+                end
             end
         end
     end

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -5602,7 +5602,7 @@ function setCurrentHealth(value)
 		value = value or 0;
 		value = math.max(0x00, value);
 		value = math.min(0xFF, value);
-		mainmemory.write_u8(0x11B644, value);
+		mainmemory.write_u8(health_table[currentTransformation], value);
         return currentTransformation
 	end
     return false

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -4531,6 +4531,94 @@ function obtain_bkmove()
     end
 end
 
+function check_progressive()
+    local beak_bust = 0
+    local eggs = 0
+    local shoes = 0
+    local swim = 0
+    local location = ""
+    for ap_id, memloc in pairs(receive_map)
+    do
+        if memloc == "1230828"
+        then
+            beak_bust = beak_bust + 1
+        end
+        if memloc == "1230829"
+        then
+            eggs = eggs + 1
+        end
+        if memloc == "1230830"
+        then
+                shoes = shoes + 1
+        end
+        if memloc == "1230831"
+        then
+            swim = swim + 1
+        end
+    end
+
+    if beak_bust == 1 then
+        BTRAMOBJ:setFlag(0x18, 7, "Beak Buster")
+    elseif beak_bust == 2 then
+        BTRAMOBJ:setFlag(0x18, 7, "Beak Buster")
+        location = "1230757"
+        AGI_MOVES[location] = true
+        set_AGI_MOVES_checks()
+    end
+
+    if eggs == 1 then
+        AGI_MOVES["1230756"] = true
+        set_AGI_MOVES_checks()
+    elseif eggs == 2 then
+        AGI_MOVES["1230756"] = true
+        AGI_MOVES["1230759"] = true
+        set_AGI_MOVES_checks()
+    elseif eggs == 3 then
+        AGI_MOVES["1230756"] = true
+        AGI_MOVES["1230759"] = true
+        AGI_MOVES["1230763"] = true
+        set_AGI_MOVES_checks()
+    elseif eggs == 4 then
+        AGI_MOVES["1230756"] = true
+        AGI_MOVES["1230759"] = true
+        AGI_MOVES["1230763"] = true
+        AGI_MOVES["1230767"] = true
+        set_AGI_MOVES_checks()
+    end
+
+    if shoes == 1 then
+        BTRAMOBJ:setFlag(0x1A, 3, "Stilt Stride")
+    elseif shoes == 2 then
+        BTRAMOBJ:setFlag(0x1A, 3, "Stilt Stride")
+        BTRAMOBJ:setFlag(0x1A, 6, "Turbo Trainers")
+    elseif shoes == 3 then
+        BTRAMOBJ:setFlag(0x1A, 3, "Stilt Stride")
+        BTRAMOBJ:setFlag(0x1A, 6, "Turbo Trainers")
+        AGI_MOVES["1230768"] = true
+        set_AGI_MOVES_checks()
+    elseif shoes == 4 then
+        BTRAMOBJ:setFlag(0x1A, 3, "Stilt Stride")
+        BTRAMOBJ:setFlag(0x1A, 6, "Turbo Trainers")
+        AGI_MOVES["1230768"] = true
+        AGI_MOVES["1230773"] = true
+        set_AGI_MOVES_checks()
+    end
+
+    if swim == 1 then
+        BTRAMOBJ:setFlag(0x1A, 4, "Dive")
+    elseif swim == 2 then
+        BTRAMOBJ:setFlag(0x1A, 4, "Dive")
+        BTRAMOBJ:setFlag(0x32, 7, "Double Air")
+        DOUBLE_AIR = true
+    elseif swim == 3 then
+        BTRAMOBJ:setFlag(0x1A, 4, "Dive")
+        BTRAMOBJ:setFlag(0x32, 7, "Double Air")
+        BTRAMOBJ:setFlag(0x1E, 5, "Fast Swimming")
+        FAST_SWIM = true
+        DOUBLE_AIR = true
+    end
+end
+
 --------------------------------- Stop N Swap --------------------------------
 
 function init_BKMYSTERY(type) -- Initialize BMK
@@ -6056,6 +6144,7 @@ function BKLogics(mapaddr)
             check_open_level(false)
         end
         clearKey()
+        check_progressive()
         obtain_breegull_bash()
     end
 end

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -7028,7 +7028,12 @@ function SendToBTClient()
     retTable["jiggy_chunks"] = JIGGY_CHUNKS;
     retTable["goggles"] = GOGGLES;
     retTable["food_stalls"] = FOOD_STALLS;
-    retTable["banjo_map"] = CURRENT_MAP;
+    if CURRENT_MAP == nil
+    then
+        retTable["banjo_map"] = 0x0;
+    else
+        retTable["banjo_map"] = CURRENT_MAP;
+    end 
     if GAME_LOADED == false
     then
         retTable["sync_ready"] = "false"

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -101,6 +101,7 @@ class BanjoTooieContext(CommonContext):
         self.jiggychunks_table = {}
         self.goggles_table = False
         self.foodstall_table = {}
+        self.current_map = 0
         self.deathlink_enabled = False
         self.deathlink_pending = False
         self.deathlink_sent_this_death = False
@@ -321,8 +322,8 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
     jiggychunklist = payload['jiggy_chunks']
     goggles = payload['goggles']
     food_stalls = payload['food_stalls']
-
     worldslist = payload['worlds']
+    banjo_map = payload['banjo_map']
 
     # The Lua JSON library serializes an empty table into a list instead of a dict. Verify types for safety:
     if isinstance(locations, list):
@@ -351,6 +352,8 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
         food_stalls = {}
     if isinstance(goggles, bool) == False:
         goggles = False
+    if isinstance(banjo_map, int) == False:
+        banjo_map = 0
 
     if "DEMO" not in locations and ctx.sync_ready == True:
         locs1 = []
@@ -487,6 +490,16 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
                         }])
                         ctx.finished_game = True
 
+        if ctx.current_map != banjo_map:
+            ctx.current_map = banjo_map
+            await ctx.send_msgs([{
+                "cmd": "Set",
+                "key": "Banjo-Tooie_map",
+                "default": hex(0),
+                "want_reply": False,
+                "operations": [{"operation": "replace",
+                    "value": hex(banjo_map)}]
+            }])
     #Send Aync Data.
     if "sync_ready" in payload and payload["sync_ready"] == "true" and ctx.sync_ready == False:
         # ctx.items_handling = 0b101

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -99,6 +99,8 @@ class BanjoTooieContext(CommonContext):
         self.mystery_table = {}
         self.roystenlist_table = {}
         self.jiggychunks_table = {}
+        self.goggles_table = False
+        self.foodstall_table = {}
         self.deathlink_enabled = False
         self.deathlink_pending = False
         self.deathlink_sent_this_death = False
@@ -317,6 +319,8 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
     cheatorewardslist = payload['cheato_rewards']
     honeybrewardslist = payload['honeyb_rewards']
     jiggychunklist = payload['jiggy_chunks']
+    goggles = payload['goggles']
+    food_stalls = payload['food_stalls']
 
     worldslist = payload['worlds']
 
@@ -343,6 +347,10 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
         jiggychunklist = {}
     if isinstance(worldslist, list):
         worldslist = {}
+    if isinstance(food_stalls, list):
+        food_stalls = {}
+    if isinstance(goggles, bool) == False:
+        goggles = False
 
     if "DEMO" not in locations and ctx.sync_ready == True:
         locs1 = []
@@ -373,6 +381,7 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
                                     if ctx.slot_data["goal_type"] == 1 or ctx.slot_data["goal_type"] == 2 or \
                                     ctx.slot_data["goal_type"] == 3 or ctx.slot_data["goal_type"] == 4:
                                        locs1 = mumbo_tokens_loc(locs1, int(locationId), ctx.slot_data["goal_type"])
+                                   
             ctx.location_table = locations       
         if ctx.chuffy_table != chuffy:
             ctx.chuffy_table = chuffy
@@ -406,7 +415,16 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
             for locationId, value in jiggychunklist.items():
                 if value == True:
                     locs1.append(int(locationId))
-        
+        if ctx.goggles_table != goggles:
+            ctx.goggles_table = goggles
+            if goggles == True:
+                locs1.append(1231005)
+        if ctx.foodstall_table != food_stalls:
+            ctx.foodstall_table = food_stalls
+            for locationId, value in food_stalls.items():
+                if value == True:
+                    locs1.append(int(locationId))
+
         if ctx.slot_data["moves"] == "true":
             # Locations handling
             movelist = payload['unlocked_moves']

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -100,7 +100,7 @@ class BanjoTooieContext(CommonContext):
         self.roystenlist_table = {}
         self.jiggychunks_table = {}
         self.goggles_table = False
-        self.foodstall_table = {}
+        self.dino_kids_table = {}
         self.current_map = 0
         self.deathlink_enabled = False
         self.deathlink_pending = False
@@ -321,7 +321,7 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
     honeybrewardslist = payload['honeyb_rewards']
     jiggychunklist = payload['jiggy_chunks']
     goggles = payload['goggles']
-    food_stalls = payload['food_stalls']
+    dino_kids = payload['dino_kids']
     worldslist = payload['worlds']
     banjo_map = payload['banjo_map']
 
@@ -348,8 +348,8 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
         jiggychunklist = {}
     if isinstance(worldslist, list):
         worldslist = {}
-    if isinstance(food_stalls, list):
-        food_stalls = {}
+    if isinstance(dino_kids, list):
+        dino_kids = {}
     if isinstance(goggles, bool) == False:
         goggles = False
     if isinstance(banjo_map, int) == False:
@@ -422,9 +422,9 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
             ctx.goggles_table = goggles
             if goggles == True:
                 locs1.append(1231005)
-        if ctx.foodstall_table != food_stalls:
-            ctx.foodstall_table = food_stalls
-            for locationId, value in food_stalls.items():
+        if ctx.dino_kids_table != dino_kids:
+            ctx.dino_kids_table = dino_kids
+            for locationId, value in dino_kids.items():
                 if value == True:
                     locs1.append(int(locationId))
 

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -494,7 +494,7 @@ async def parse_payload(payload: dict, ctx: BanjoTooieContext, force: bool):
             ctx.current_map = banjo_map
             await ctx.send_msgs([{
                 "cmd": "Set",
-                "key": "Banjo-Tooie_map",
+                "key": f"Banjo_Tooie_{ctx.team}_{ctx.slot}_map",
                 "default": hex(0),
                 "want_reply": False,
                 "operations": [{"operation": "replace",

--- a/worlds/banjo_tooie/Items.py
+++ b/worlds/banjo_tooie/Items.py
@@ -71,7 +71,7 @@ moves_table = {
 
     itemName.SAPACK:        ItemData(1230776, 1, "progress", locationName.SAPACK),
 
-    itemName.FSWIM:         ItemData(1230777, 1, "progress", locationName.ROYSTEN1),
+    itemName.FSWIM:         ItemData(1230777, 1, "useful", locationName.ROYSTEN1),
     itemName.DAIR:          ItemData(1230779, 1, "progress", locationName.ROYSTEN2),
 }
 
@@ -98,7 +98,8 @@ bk_moves_table = {
 
 progressive_ability_table = {
     itemName.PBBUST:        ItemData(1230828, 2, "progress", ""),
-    itemName.PBEGGS:        ItemData(1230829, 4, "progress", "")
+    itemName.PBEGGS:        ItemData(1230829, 4, "progress", ""),
+    itemName.PSHOES:        ItemData(1230830, 4, "progress", "")
 }
 
 level_progress_table = {

--- a/worlds/banjo_tooie/Items.py
+++ b/worlds/banjo_tooie/Items.py
@@ -90,11 +90,15 @@ bk_moves_table = {
     itemName.TTRAIN:        ItemData(1230821, 1, "progress", ""),
     itemName.ARAT:          ItemData(1230822, 1, "progress", ""),
     itemName.BEGG:          ItemData(1230823, 1, "progress", ""),
+    itemName.GRAT:          ItemData(1230824, 1, "progress", ""),
+    itemName.BBARGE:        ItemData(1230825, 1, "progress", ""),
+    itemName.SSTRIDE:       ItemData(1230826, 1, "progress", ""),
+    itemName.BBOMB:         ItemData(1230827, 1, "progress", "")
 }
 
 progressive_ability_table = {
-    itemName.PBBUST:        ItemData(1230824, 2, "progress", ""),
-    itemName.PBEGGS:        ItemData(1230825, 4, "progress", "")
+    itemName.PBBUST:        ItemData(1230828, 2, "progress", ""),
+    itemName.PBEGGS:        ItemData(1230829, 4, "progress", "")
 }
 
 level_progress_table = {

--- a/worlds/banjo_tooie/Items.py
+++ b/worlds/banjo_tooie/Items.py
@@ -38,41 +38,30 @@ moves_table = {
     itemName.GGRAB:         ItemData(1230753, 1, "progress", locationName.GGRAB),
     itemName.BBLASTER:      ItemData(1230754, 1, "progress", locationName.BBLASTER),
     itemName.EGGAIM:        ItemData(1230755, 1, "progress", locationName.EGGAIM),
-
     itemName.FEGGS:         ItemData(1230756, 1, "progress", locationName.FEGGS),
-
     itemName.BDRILL:        ItemData(1230757, 1, "progress", locationName.BDRILL),
     itemName.BBAYONET:      ItemData(1230758, 1, "progress", locationName.BBAYONET),
-
     itemName.GEGGS:         ItemData(1230759, 1, "progress", locationName.GEGGS),
-
     itemName.AIREAIM:       ItemData(1230760, 1, "progress", locationName.AIREAIM),
     itemName.SPLITUP:       ItemData(1230761, 1, "progress", locationName.SPLITUP),
     itemName.PACKWH:        ItemData(1230762, 1, "progress", locationName.PACKWH),
-    
     itemName.IEGGS:         ItemData(1230763, 1, "progress", locationName.IEGGS),
-
     itemName.WWHACK:        ItemData(1230764, 1, "progress", locationName.WWHACK),
     itemName.TTORP:         ItemData(1230765, 1, "progress", locationName.TTORP),
     itemName.AUQAIM:        ItemData(1230766, 1, "progress", locationName.AUQAIM),
-
     itemName.CEGGS:         ItemData(1230767, 1, "progress", locationName.CEGGS),
-
     itemName.SPRINGB:       ItemData(1230768, 1, "progress", locationName.SPRINGB),
     itemName.TAXPACK:       ItemData(1230769, 1, "progress", locationName.TAXPACK),
     itemName.HATCH:         ItemData(1230770, 1, "progress", locationName.HATCH),
-
     itemName.SNPACK:        ItemData(1230771, 1, "progress", locationName.SNPACK),
     itemName.LSPRING:       ItemData(1230772, 1, "progress", locationName.LSPRING),
     itemName.CLAWBTS:       ItemData(1230773, 1, "progress", locationName.CLAWBTS),
-
     itemName.SHPACK:        ItemData(1230774, 1, "progress", locationName.SHPACK),
     itemName.GLIDE:         ItemData(1230775, 1, "progress", locationName.GLIDE),
-
     itemName.SAPACK:        ItemData(1230776, 1, "progress", locationName.SAPACK),
-
     itemName.FSWIM:         ItemData(1230777, 1, "useful", locationName.ROYSTEN1),
     itemName.DAIR:          ItemData(1230779, 1, "progress", locationName.ROYSTEN2),
+    itemName.AMAZEOGAZE:    ItemData(1230780, 1, "progress", locationName.GOGGLES)
 }
 
 bk_moves_table = {

--- a/worlds/banjo_tooie/Items.py
+++ b/worlds/banjo_tooie/Items.py
@@ -99,7 +99,9 @@ bk_moves_table = {
 progressive_ability_table = {
     itemName.PBBUST:        ItemData(1230828, 2, "progress", ""),
     itemName.PBEGGS:        ItemData(1230829, 4, "progress", ""),
-    itemName.PSHOES:        ItemData(1230830, 4, "progress", "")
+    itemName.PSHOES:        ItemData(1230830, 4, "progress", ""),
+    itemName.PSWIM:         ItemData(1230831, 3, "progress", ""),
+    itemName.PBASH:         ItemData(1230832, 2, "progress", "")
 }
 
 level_progress_table = {

--- a/worlds/banjo_tooie/Locations.py
+++ b/worlds/banjo_tooie/Locations.py
@@ -7,7 +7,7 @@ class BanjoTooieLocation(Location):
     game: str = "Banjo-Tooie"
     
 class LocationData(typing.NamedTuple):
-    #last good ID: 1231007
+    #last good ID: 1231008
     #12C770 pointer instead (1230704)
     btid: int = 0
     # Save + mem addr
@@ -45,7 +45,7 @@ JVLoc_table = {
     locationName.JIGGYIH10: LocationData(1230685, 0x50, 1),
     locationName.TREBLEJV:  LocationData(1230789, 0x97, 7),  #Set last ID for Clef Family. Client Reasons
     locationName.IKEY:      LocationData(1230958, 0, 0), #Needs to be handled on client side
-    locationName.BOTTLEKID: LocationData(1231005, 0x1E, 0)
+    locationName.GOGGLES: LocationData(1231005, 0x1E, 0) #actually watching 0x30, bit 1
 }
 
 MTLoc_Table = {
@@ -215,8 +215,6 @@ WWLoc_table = {
     locationName.NOTEWW14:  LocationData(1230845, 0x8A, 6),
     locationName.NOTEWW15:  LocationData(1230846, 0x8A, 7),
     locationName.NOTEWW16:  LocationData(1230847, 0x8B, 0),
-    locationName.BIGAL:     LocationData(1231006, 0, 0), #Implement on Client Side
-    locationName.SALTYJOE:  LocationData(1231007, 0, 0) #Implement on Client Side
 }
 
 JRLoc_table = {
@@ -339,7 +337,10 @@ TLLoc_table = {
     locationName.NOTETDL13:  LocationData(1230876, 0x8E, 7),
     locationName.NOTETDL14:  LocationData(1230877, 0x8F, 0),
     locationName.NOTETDL15:  LocationData(1230878, 0x8F, 1),
-    locationName.NOTETDL16:  LocationData(1230879, 0x8F, 2)
+    locationName.NOTETDL16:  LocationData(1230879, 0x8F, 2),
+    locationName.SCRUT:      LocationData(1231006, 0, 0), #Implement on Client Side
+    locationName.SCRAT:      LocationData(1231007, 0, 0), #Implement on Client Side
+    locationName.SCRIT:      LocationData(1231008, 0, 0), #Implement on Client Side
 }
 
 GILoc_table = {

--- a/worlds/banjo_tooie/Locations.py
+++ b/worlds/banjo_tooie/Locations.py
@@ -7,7 +7,7 @@ class BanjoTooieLocation(Location):
     game: str = "Banjo-Tooie"
     
 class LocationData(typing.NamedTuple):
-    #last good ID: 1231004
+    #last good ID: 1231007
     #12C770 pointer instead (1230704)
     btid: int = 0
     # Save + mem addr
@@ -45,7 +45,7 @@ JVLoc_table = {
     locationName.JIGGYIH10: LocationData(1230685, 0x50, 1),
     locationName.TREBLEJV:  LocationData(1230789, 0x97, 7),  #Set last ID for Clef Family. Client Reasons
     locationName.IKEY:      LocationData(1230958, 0, 0), #Needs to be handled on client side
-
+    locationName.BOTTLEKID: LocationData(1231005, 0x1E, 0)
 }
 
 MTLoc_Table = {
@@ -214,7 +214,9 @@ WWLoc_table = {
     locationName.NOTEWW13:  LocationData(1230844, 0x8A, 5),
     locationName.NOTEWW14:  LocationData(1230845, 0x8A, 6),
     locationName.NOTEWW15:  LocationData(1230846, 0x8A, 7),
-    locationName.NOTEWW16:  LocationData(1230847, 0x8B, 0)
+    locationName.NOTEWW16:  LocationData(1230847, 0x8B, 0),
+    locationName.BIGAL:     LocationData(1231006, 0, 0), #Implement on Client Side
+    locationName.SALTYJOE:  LocationData(1231007, 0, 0) #Implement on Client Side
 }
 
 JRLoc_table = {

--- a/worlds/banjo_tooie/Names/itemName.py
+++ b/worlds/banjo_tooie/Names/itemName.py
@@ -73,6 +73,8 @@ EGGSHOOT    = "Egg Shoot"
 PBBUST       = "Progressive Beak Buster"
 PBEGGS       = "Progressive Eggs"
 PSHOES       = "Progressive Shoes"
+PSWIM       = "Progressive Water Training"
+PBASH       = "Progressive Bash Attack"
 
 # Mumbo Magics
 MUMBOMT = "Mumbo: Golden Goliath"

--- a/worlds/banjo_tooie/Names/itemName.py
+++ b/worlds/banjo_tooie/Names/itemName.py
@@ -53,21 +53,21 @@ HOMINGEGGS  = "Homing Eggs Toggle"
 
 DIVE        = "Dive"
 FPAD        = "Flight Pad"
-GRAT        = "Ground Rat-a-tat Rap" #NOT IMPLEMENTED YET
+GRAT        = "Ground Rat-a-tat Rap"
 ROLL        = "Roll"
 ARAT        = "Air Rat-a-tat Rap"
-BBARGE      = "Beak Barge" #NOT IMPLEMENTED YET
+BBARGE      = "Beak Barge"
 TJUMP        = "Tall jump"
 FLUTTER     = "Flutter"
 FFLIP       = "Flap Flip"
 CLIMB      = "Climb"
-BEGG        = "Blue Eggs" #NOT IMPLEMENTED YET
+BEGG        = "Blue Eggs"
 TTROT       = "Talon Trot"
 BBUST       = "Beak Buster"
 WWING       = "Wonderwing"
-SSTRIDE      = "Stilt Stride" #NOT IMPLEMENTED YET
+SSTRIDE      = "Stilt Stride"
 TTRAIN      = "Turbo Trainers"
-BBOMB       = "Beak Bomb" #NOT IMPLEMENTED YET
+BBOMB       = "Beak Bomb"
 EGGSHOOT    = "Egg Shoot"
 
 PBBUST       = "Progressive Beak Buster"

--- a/worlds/banjo_tooie/Names/itemName.py
+++ b/worlds/banjo_tooie/Names/itemName.py
@@ -50,6 +50,7 @@ FSWIM       = "Fast Swimming"
 DAIR        = "Double Air"
 BBASH       = "Breegull Bash"
 HOMINGEGGS  = "Homing Eggs Toggle"
+AMAZEOGAZE  = "Amaze-O-Gaze"
 
 DIVE        = "Dive"
 FPAD        = "Flight Pad"

--- a/worlds/banjo_tooie/Names/itemName.py
+++ b/worlds/banjo_tooie/Names/itemName.py
@@ -72,6 +72,7 @@ EGGSHOOT    = "Egg Shoot"
 
 PBBUST       = "Progressive Beak Buster"
 PBEGGS       = "Progressive Eggs"
+PSHOES       = "Progressive Shoes"
 
 # Mumbo Magics
 MUMBOMT = "Mumbo: Golden Goliath"

--- a/worlds/banjo_tooie/Names/locationName.py
+++ b/worlds/banjo_tooie/Names/locationName.py
@@ -449,9 +449,10 @@ HONEYBR2    = "IoH: Honey B's Reward 2" # 3
 HONEYBR3    = "IoH: Honey B's Reward 3" # 5
 HONEYBR4    = "IoH: Honey B's Reward 4" # 7
 HONEYBR5    = "IoH: Honey B's Reward 5" # 9
-BOTTLEKID   = "BH: Goggles Amaze-O-Gaze"
-BIGAL       = "WW: Big Al's Burgers"
-SALTYJOE    = "WW: Salty Joe's Fries"
+GOGGLES     = "BH: Goggles Amaze-O-Gaze"
+SCRUT       = "TDL: Scrut"
+SCRAT       = "TDL: Scrat"
+SCRIT       = "TDL: Scrit"
 
 #Jiggy Chunks
 CHUNK1      = "GGM: Crushing Shed Jiggy Chunk 1"

--- a/worlds/banjo_tooie/Names/locationName.py
+++ b/worlds/banjo_tooie/Names/locationName.py
@@ -449,6 +449,9 @@ HONEYBR2    = "IoH: Honey B's Reward 2" # 3
 HONEYBR3    = "IoH: Honey B's Reward 3" # 5
 HONEYBR4    = "IoH: Honey B's Reward 4" # 7
 HONEYBR5    = "IoH: Honey B's Reward 5" # 9
+BOTTLEKID   = "BH: Goggles Amaze-O-Gaze"
+BIGAL       = "WW: Big Al's Burgers"
+SALTYJOE    = "WW: Salty Joe's Fries"
 
 #Jiggy Chunks
 CHUNK1      = "GGM: Crushing Shed Jiggy Chunk 1"

--- a/worlds/banjo_tooie/Options.py
+++ b/worlds/banjo_tooie/Options.py
@@ -26,6 +26,10 @@ class EggsBehaviour(Choice):
     option_progressive_eggs = 2
     default = 0
 
+class ProgressiveShoes(Toggle):
+    """Stilt Stride to Turbo Trainers to Spring Boots to Claw Climber Boots. Randomize Moves and Randomize BK Moves is required."""
+    display_name = "Progressive Kazooie Shoes"
+
 class EnableCheatoRewards(DefaultOnToggle):
     """Cheato rewards you a cheat + an additional randomized reward. Use Cheato Pages as Filler cannot be set if this is enabled."""
     display_name = "Cheato Rewards"
@@ -282,6 +286,7 @@ class BanjoTooieOptions(PerGameCommonOptions):
     randomize_bk_moves: EnableMultiWorldBKMoveList
     progressive_beak_buster: ProgressiveBeakBuster
     egg_behaviour:EggsBehaviour
+    progressive_shoes: ProgressiveShoes
     randomize_jinjos: EnableMultiWorldJinjos
     forbid_on_jinjo_family: ForbidMovesOnJinjoFamilyTreasure
     forbid_jinjos_on_jinjo_family: ForbidJinjosOnJinjoFamilyTreasure

--- a/worlds/banjo_tooie/Options.py
+++ b/worlds/banjo_tooie/Options.py
@@ -30,6 +30,14 @@ class ProgressiveShoes(Toggle):
     """Stilt Stride to Turbo Trainers to Spring Boots to Claw Climber Boots. Randomize Moves and Randomize BK Moves is required."""
     display_name = "Progressive Kazooie Shoes"
 
+class ProgressiveSwimming(Toggle):
+    """Dive to Double Air to Faster Swimming. Randomize Moves and Randomize BK Moves is required."""
+    display_name = "Progressive Water Training"
+
+class ProgressiveBashAttack(Toggle):
+    """Ground Rat-a-tat Rap to Breegull Bash. Randomize Stop N Swap and Randomize BK Moves is required"""
+    display_name = "Progressive Bash Attack"
+
 class EnableCheatoRewards(DefaultOnToggle):
     """Cheato rewards you a cheat + an additional randomized reward. Use Cheato Pages as Filler cannot be set if this is enabled."""
     display_name = "Cheato Rewards"
@@ -287,6 +295,8 @@ class BanjoTooieOptions(PerGameCommonOptions):
     progressive_beak_buster: ProgressiveBeakBuster
     egg_behaviour:EggsBehaviour
     progressive_shoes: ProgressiveShoes
+    progressive_water_training: ProgressiveSwimming
+    progressive_bash_attack: ProgressiveBashAttack
     randomize_jinjos: EnableMultiWorldJinjos
     forbid_on_jinjo_family: ForbidMovesOnJinjoFamilyTreasure
     forbid_jinjos_on_jinjo_family: ForbidJinjosOnJinjoFamilyTreasure

--- a/worlds/banjo_tooie/Regions.py
+++ b/worlds/banjo_tooie/Regions.py
@@ -30,7 +30,7 @@ BANJOTOOIEREGIONS: typing.Dict[str, typing.List[str]] = {
         locationName.JIGGYIH10,
         locationName.TREBLEJV,
         locationName.IKEY,
-        locationName.BOTTLEKID
+        locationName.GOGGLES
     ],
     regionName.IOHWH:    [
         locationName.JINJOIH1,
@@ -211,9 +211,7 @@ BANJOTOOIEREGIONS: typing.Dict[str, typing.List[str]] = {
         locationName.NOTEWW13,
         locationName.NOTEWW14,
         locationName.NOTEWW15,
-        locationName.NOTEWW16,
-        locationName.BIGAL,
-        locationName.SALTYJOE
+        locationName.NOTEWW16
     ],
     regionName.IOHCT:   [
         locationName.JINJOIH3,
@@ -360,7 +358,10 @@ BANJOTOOIEREGIONS: typing.Dict[str, typing.List[str]] = {
         locationName.NOTETDL13,
         locationName.NOTETDL14,
         locationName.NOTETDL15,
-        locationName.NOTETDL16
+        locationName.NOTETDL16,
+        locationName.SCRUT,
+        locationName.SCRAT,
+        locationName.SCRIT
     ],
     regionName.TL_HATCH: [
         locationName.HATCH,

--- a/worlds/banjo_tooie/Regions.py
+++ b/worlds/banjo_tooie/Regions.py
@@ -30,6 +30,7 @@ BANJOTOOIEREGIONS: typing.Dict[str, typing.List[str]] = {
         locationName.JIGGYIH10,
         locationName.TREBLEJV,
         locationName.IKEY,
+        locationName.BOTTLEKID
     ],
     regionName.IOHWH:    [
         locationName.JINJOIH1,
@@ -210,7 +211,9 @@ BANJOTOOIEREGIONS: typing.Dict[str, typing.List[str]] = {
         locationName.NOTEWW13,
         locationName.NOTEWW14,
         locationName.NOTEWW15,
-        locationName.NOTEWW16  
+        locationName.NOTEWW16,
+        locationName.BIGAL,
+        locationName.SALTYJOE
     ],
     regionName.IOHCT:   [
         locationName.JINJOIH3,

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -1818,7 +1818,7 @@ class BanjoTooieRules:
             logic = (self.hasBKMove(state, itemName.FFLIP) or self.ggm_trot(state) or self.canReachSlightlyElevatedLedge(state)) and self.billDrill(state)\
                      or self.humbaGGM(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.hasBKMove(state, itemName.FFLIP) or self.ggm_trot(state) or self.canReachSlightlyElevatedLedge(state) and self.billDrill(state)) or \
+            logic = ((self.hasBKMove(state, itemName.FFLIP) or self.ggm_trot(state) or self.canReachSlightlyElevatedLedge(state)) and self.billDrill(state)) or \
                 self.humbaGGM(state) or self.egg_barge(state)
         return logic
     

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -502,7 +502,7 @@ class BanjoTooieRules:
         }
 
         self.jinjo_rules = {
-            locationName.JINJOIH5: lambda state: state.has(itemName.TTORP, self.player) and self.hasBKMove(state, itemName.DIVE),
+            locationName.JINJOIH5: lambda state: state.has(itemName.TTORP, self.player) and self.dive(state),
             locationName.JINJOIH4: lambda state: self.jinjo_plateau(state),
             locationName.JINJOIH3: lambda state: self.jinjo_clifftop(state),
             locationName.JINJOIH2: lambda state: self.jinjo_wasteland(state),
@@ -529,7 +529,7 @@ class BanjoTooieRules:
             locationName.JINJOJR5: lambda state: self.jinjo_sunkenship(state),
 
             locationName.JINJOTL2: lambda state: self.jinjo_tdlentrance(state),
-            locationName.JINJOTL1: lambda state: state.has(itemName.TTORP, self.player) and self.hasBKMove(state, itemName.DIVE),
+            locationName.JINJOTL1: lambda state: state.has(itemName.TTORP, self.player) and self.dive(state),
             locationName.JINJOTL3: lambda state: self.clockworkEggs(state),
             locationName.JINJOTL4: lambda state: self.jinjo_big_t_rex(state),
             locationName.JINJOTL5: lambda state: self.jinjo_stomping_plains(state),
@@ -638,7 +638,7 @@ class BanjoTooieRules:
             locationName.NOTECCL4: lambda state: self.notes_ccl_silo(state),
             locationName.NOTECCL5: lambda state: self.notes_ccl_high(state),
             locationName.NOTECCL6: lambda state: self.notes_ccl_low(state),
-            locationName.NOTECCL7: lambda state: self.hasBKMove(state, itemName.DIVE),
+            locationName.NOTECCL7: lambda state: self.dive(state),
             locationName.NOTECCL8: lambda state: self.notes_ccl_low(state),
             locationName.NOTECCL9: lambda state: self.notes_ccl_low(state),
             locationName.NOTECCL10: lambda state: self.notes_ccl_high(state),
@@ -763,19 +763,19 @@ class BanjoTooieRules:
     def jiggy_pillars(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.billDrill(state) and (self.hasBKMove(state, itemName.DIVE) or self.canReachSlightlyElevatedLedge(state))\
+            logic = self.billDrill(state) and (self.dive(state) or self.canReachSlightlyElevatedLedge(state))\
                     and self.canDoSmallElevation(state) and self.prison_compound_open(state)
         elif self.world.options.logic_type == 1: # normal
             logic = self.billDrill(state) and self.canDoSmallElevation(state) and self.prison_compound_open(state)\
-                    and (self.hasBKMove(state, itemName.DIVE) or self.canReachSlightlyElevatedLedge(state) or self.beakBuster(state))
+                    and (self.dive(state) or self.canReachSlightlyElevatedLedge(state) or self.beakBuster(state))
         elif self.world.options.logic_type == 2: # advanced
             logic = self.prison_compound_open(state) and \
                 ((self.billDrill(state) and self.canDoSmallElevation(state)) or self.extremelyLongJump(state))\
-                    and (self.hasBKMove(state, itemName.DIVE) or self.canReachSlightlyElevatedLedge(state) or self.beakBuster(state))
+                    and (self.dive(state) or self.canReachSlightlyElevatedLedge(state) or self.beakBuster(state))
         elif self.world.options.logic_type == 3: # glitched
             logic = self.prison_compound_open(state) and \
                 ((self.billDrill(state) and self.canDoSmallElevation(state)) or self.extremelyLongJump(state))\
-                    and (self.hasBKMove(state, itemName.DIVE) or self.canReachSlightlyElevatedLedge(state) or self.beakBuster(state))
+                    and (self.dive(state) or self.canReachSlightlyElevatedLedge(state) or self.beakBuster(state))
         return logic
     
     def jiggy_top(self, state: CollectionState) -> bool:
@@ -904,18 +904,18 @@ class BanjoTooieRules:
     def jiggy_flooded_caves(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.humbaGGM(state) and self.hasBKMove(state, itemName.DIVE)
+            logic = self.humbaGGM(state) and self.dive(state)
 
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.TJUMP) and\
+            logic = self.dive(state) and self.hasBKMove(state, itemName.TJUMP) and\
                 (self.humbaGGM(state) or self.longJump(state))
             
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.TJUMP) and\
+            logic = self.dive(state) and self.hasBKMove(state, itemName.TJUMP) and\
                 (self.humbaGGM(state) or self.longJump(state))
             
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.TJUMP) and\
+            logic = self.dive(state) and self.hasBKMove(state, itemName.TJUMP) and\
                 (self.humbaGGM(state) or self.longJump(state))
         return logic
     
@@ -1203,12 +1203,12 @@ class BanjoTooieRules:
                 and (self.check_humba_magic(state, itemName.HUMBAJR) or self.check_mumbo_magic(state, itemName.MUMBOJR))
         elif self.world.options.logic_type == 2: # advanced
             logic = self.can_reach_atlantis(state) and self.grenadeEggs(state) and state.has(itemName.AUQAIM, self.player) and \
-                ((state.has(itemName.TTORP, self.player) and state.has(itemName.DAIR, self.player)) or \
+                ((state.has(itemName.TTORP, self.player) and self.doubleAir(state)) or \
                      self.check_mumbo_magic(state, itemName.MUMBOJR) or \
                     self.check_humba_magic(state, itemName.HUMBAJR))
         elif self.world.options.logic_type == 3: # glitched
             logic = self.can_reach_atlantis(state) and self.grenadeEggs(state) and state.has(itemName.AUQAIM, self.player) and \
-                ((state.has(itemName.TTORP, self.player) and state.has(itemName.DAIR, self.player)) or \
+                ((state.has(itemName.TTORP, self.player) and self.doubleAir(state)) or \
                      self.check_mumbo_magic(state, itemName.MUMBOJR) or \
                     self.check_humba_magic(state, itemName.HUMBAJR))
         return logic
@@ -1271,13 +1271,13 @@ class BanjoTooieRules:
     def jiggy_dippy(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.TTORP, self.player) and state.can_reach_region(regionName.CC, self.player) and self.hasBKMove(state, itemName.DIVE)
+            logic = state.has(itemName.TTORP, self.player) and state.can_reach_region(regionName.CC, self.player) and self.dive(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.TTORP, self.player) and state.can_reach_region(regionName.CC, self.player) and self.hasBKMove(state, itemName.DIVE)
+            logic = state.has(itemName.TTORP, self.player) and state.can_reach_region(regionName.CC, self.player) and self.dive(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.TTORP, self.player) and state.can_reach_region(regionName.CC, self.player) and self.hasBKMove(state, itemName.DIVE)
+            logic = state.has(itemName.TTORP, self.player) and state.can_reach_region(regionName.CC, self.player) and self.dive(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.has(itemName.TTORP, self.player) and state.can_reach_region(regionName.CC, self.player) and self.hasBKMove(state, itemName.DIVE)
+            logic = state.has(itemName.TTORP, self.player) and state.can_reach_region(regionName.CC, self.player) and self.dive(state)
         return logic
     
     def jiggy_scrotty(self, state: CollectionState) -> bool:
@@ -2179,16 +2179,16 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = state.has(itemName.GGRAB, self.player) and self.hasBKMove(state, itemName.FFLIP)\
-                    and self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.CLIMB)
+                    and self.dive(state) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 1: # normal
             logic = (state.has(itemName.GGRAB, self.player) or self.beakBuster(state))\
-                    and self.hasBKMove(state, itemName.FFLIP) and self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.CLIMB)
+                    and self.hasBKMove(state, itemName.FFLIP) and self.dive(state) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 2: # advanced
             logic = (state.has(itemName.GGRAB, self.player) or self.beakBuster(state))\
-                    and self.hasBKMove(state, itemName.FFLIP) and self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.CLIMB)
+                    and self.hasBKMove(state, itemName.FFLIP) and self.dive(state) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 3: # glitched
             logic = (state.has(itemName.GGRAB, self.player) or self.beakBuster(state))\
-                    and self.hasBKMove(state, itemName.FFLIP) and self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.CLIMB)\
+                    and self.hasBKMove(state, itemName.FFLIP) and self.dive(state) and self.hasBKMove(state, itemName.CLIMB)\
                     or self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE)
         return logic
     
@@ -2292,16 +2292,16 @@ class BanjoTooieRules:
     def cheato_dippypool(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.hasBKMove(state, itemName.DIVE)\
+            logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.dive(state)\
                 and ((self.canDoSmallElevation(state) and self.springBoots(state)) or self.TDLFlightPad(state))
         elif self.world.options.logic_type == 1: # normal
-            logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.hasBKMove(state, itemName.DIVE)\
+            logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.dive(state)\
                 and ((self.canDoSmallElevation(state) and self.springBoots(state)) or self.TDLFlightPad(state))
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.hasBKMove(state, itemName.DIVE)\
+            logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.dive(state)\
                 and ((self.canDoSmallElevation(state) and self.springBoots(state)) or self.TDLFlightPad(state))
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.hasBKMove(state, itemName.DIVE)\
+            logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.dive(state)\
                 and ((self.canDoSmallElevation(state) and self.springBoots(state)) or self.TDLFlightPad(state))
         return logic
     
@@ -2494,13 +2494,13 @@ class BanjoTooieRules:
     def glowbo_cavern(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.cclStarterPack(state) and self.hasBKMove(state, itemName.DIVE)
+            logic = self.cclStarterPack(state) and self.dive(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.cclStarterPack(state) and self.hasBKMove(state, itemName.DIVE)
+            logic = self.cclStarterPack(state) and self.dive(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.cclStarterPack(state) and self.hasBKMove(state, itemName.DIVE)
+            logic = self.cclStarterPack(state) and self.dive(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.cclStarterPack(state) and self.hasBKMove(state, itemName.DIVE)
+            logic = self.cclStarterPack(state) and self.dive(state)
         return logic
     
     def glowbo_cliff(self, state: CollectionState) -> bool:
@@ -2519,17 +2519,17 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = state.has(itemName.TTORP, self.player) and state.has(itemName.IKEY, self.player)\
-                    and self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.TJUMP)
+                    and self.dive(state) and self.hasBKMove(state, itemName.TJUMP)
         elif self.world.options.logic_type == 1: # normal
             logic = state.has(itemName.TTORP, self.player) and state.has(itemName.IKEY, self.player)\
-                    and self.hasBKMove(state, itemName.DIVE) and (self.hasBKMove(state, itemName.TJUMP) or self.beakBuster(state))
+                    and self.dive(state) and (self.hasBKMove(state, itemName.TJUMP) or self.beakBuster(state))
         elif self.world.options.logic_type == 2: # advanced
             logic = state.has(itemName.TTORP, self.player) and state.has(itemName.IKEY, self.player)\
-                    and self.hasBKMove(state, itemName.DIVE) and\
+                    and self.dive(state) and\
                     (self.hasBKMove(state, itemName.TJUMP) or self.beakBuster(state) or self.clockwork_shot(state))
         elif self.world.options.logic_type == 3: # glitched
             logic = state.has(itemName.TTORP, self.player) and state.has(itemName.IKEY, self.player)\
-                        and self.hasBKMove(state, itemName.DIVE) and\
+                        and self.dive(state) and\
                         (self.hasBKMove(state, itemName.TJUMP) or self.beakBuster(state) or self.clockwork_shot(state))
         return logic
 
@@ -2647,7 +2647,7 @@ class BanjoTooieRules:
     def jinjo_pool(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 1: # normal
             logic = True
         elif self.world.options.logic_type == 2: # advanced
@@ -3042,13 +3042,13 @@ class BanjoTooieRules:
     def treble_gm(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.hasBKMove(state,itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state,itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.hasBKMove(state,itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state,itemName.DIVE) or (self.GM_boulders(state) and self.check_solo_moves(state, itemName.LSPRING))
+            logic = self.dive(state) or (self.GM_boulders(state) and self.check_solo_moves(state, itemName.LSPRING))
         return logic
     
     def treble_ww(self, state: CollectionState) -> bool:
@@ -3235,13 +3235,13 @@ class BanjoTooieRules:
     def doubloon_water(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state, itemName.DIVE) or self.check_solo_moves(state, itemName.SHPACK) and self.has_explosives(state)
+            logic = self.dive(state) or self.check_solo_moves(state, itemName.SHPACK) and self.has_explosives(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.hasBKMove(state, itemName.DIVE) or self.check_solo_moves(state, itemName.SHPACK) and self.has_explosives(state)
+            logic = self.dive(state) or self.check_solo_moves(state, itemName.SHPACK) and self.has_explosives(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state, itemName.DIVE) or self.check_solo_moves(state, itemName.SHPACK) and self.has_explosives(state)
+            logic = self.dive(state) or self.check_solo_moves(state, itemName.SHPACK) and self.has_explosives(state)
         return logic
 
     def notes_plateau_sign(self, state: CollectionState) -> bool:
@@ -3280,7 +3280,7 @@ class BanjoTooieRules:
     def notes_dive_of_death(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = ((state.has(itemName.GGRAB, self.player) and self.hasBKMove(state, itemName.FFLIP)) or self.hasBKMove(state, itemName.CLIMB)) and self.hasBKMove(state, itemName.DIVE)
+            logic = ((state.has(itemName.GGRAB, self.player) and self.hasBKMove(state, itemName.FFLIP)) or self.hasBKMove(state, itemName.CLIMB)) and self.dive(state)
         elif self.world.options.logic_type == 1: # normal
             logic = (((state.has(itemName.GGRAB, self.player) or self.beakBuster(state)) and self.hasBKMove(state, itemName.FFLIP)) or self.hasBKMove(state, itemName.CLIMB))
         elif self.world.options.logic_type == 2: # advanced
@@ -3404,13 +3404,13 @@ class BanjoTooieRules:
     def notes_river_passage(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state, itemName.DIVE) or self.humbaTDL(state) or self.check_solo_moves(state, itemName.SHPACK)
+            logic = self.dive(state) or self.humbaTDL(state) or self.check_solo_moves(state, itemName.SHPACK)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.hasBKMove(state, itemName.DIVE) or self.humbaTDL(state) or self.check_solo_moves(state, itemName.SHPACK)
+            logic = self.dive(state) or self.humbaTDL(state) or self.check_solo_moves(state, itemName.SHPACK)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state, itemName.DIVE) or self.humbaTDL(state) or self.check_solo_moves(state, itemName.SHPACK)
+            logic = self.dive(state) or self.humbaTDL(state) or self.check_solo_moves(state, itemName.SHPACK)
         return logic
     
     def notes_gi_floor1(self, state: CollectionState) -> bool:
@@ -3541,9 +3541,9 @@ class BanjoTooieRules:
     def ccl_glowbo_pool(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 2: # advanced
             logic = True # Jumping in the pool outside and going through the loading zone gives dive for free.
         elif self.world.options.logic_type == 3: # glitched
@@ -3658,13 +3658,13 @@ class BanjoTooieRules:
 
     def long_swim(self, state: CollectionState) -> bool:
         if self.world.options.logic_type == 0: # beginner
-            return self.check_mumbo_magic(state, itemName.MUMBOJR) and self.hasBKMove(state, itemName.DIVE)
+            return self.check_mumbo_magic(state, itemName.MUMBOJR) and self.dive(state)
         elif self.world.options.logic_type == 1: # normal
-            return (state.has(itemName.DAIR, self.player) or self.check_mumbo_magic(state, itemName.MUMBOJR)) and self.hasBKMove(state, itemName.DIVE)
+            return (self.doubleAir(state) or self.check_mumbo_magic(state, itemName.MUMBOJR)) and self.dive(state)
         elif self.world.options.logic_type == 2: # advanced
-            return self.hasBKMove(state, itemName.DIVE)
+            return self.dive(state)
         elif self.world.options.logic_type == 3: # glitched
-            return self.hasBKMove(state, itemName.DIVE)
+            return self.dive(state)
 
     def can_reach_atlantis(self, state: CollectionState) -> bool:
         if self.world.options.logic_type == 0: # beginner
@@ -3853,7 +3853,7 @@ class BanjoTooieRules:
             logic = (self.can_beat_weldar(state) and (self.check_solo_moves(state, itemName.SHPACK) or self.check_solo_moves(state, itemName.LSPRING)))\
                     or self.can_use_battery(state) and (
                         (self.hasBKMove(state, itemName.CLIMB) and self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.TTORP, self.player)\
-                         and self.hasBKMove(state, itemName.DIVE) and self.hasBKMove(state, itemName.WWING))
+                         and self.dive(state) and self.hasBKMove(state, itemName.WWING))
                          or (self.check_solo_moves(state, itemName.SHPACK) and self.hasBKMove(state, itemName.CLIMB) and state.has(itemName.GGRAB, self.player)))
         return logic
     
@@ -4356,7 +4356,7 @@ class BanjoTooieRules:
         logic = True
         # Going through the loading zone gives you dive for free, which is a thing beginners would not know.
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.TTORP, self.player) and self.hasBKMove(state, itemName.DIVE)
+            logic = state.has(itemName.TTORP, self.player) and self.dive(state)
         elif self.world.options.logic_type == 1 : # normal
             logic = state.has(itemName.TTORP, self.player)
         elif self.world.options.logic_type == 2: # advanced
@@ -4368,13 +4368,13 @@ class BanjoTooieRules:
     def can_dive_in_jrl(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         return logic
     
     def JRL_to_CT(self, state: CollectionState) -> bool:
@@ -4469,7 +4469,7 @@ class BanjoTooieRules:
                state.can_reach_region(regionName.CC, self.player) and \
                state.has(itemName.SPLITUP, self.player) and\
                self.hasGroundAttack(state) and\
-               self.hasBKMove(state, itemName.DIVE)
+               self.dive(state)
 
     def can_use_floatus(self, state) -> bool:
         return self.check_solo_moves(state, itemName.TAXPACK) and self.check_solo_moves(state, itemName.HATCH)
@@ -4633,6 +4633,12 @@ class BanjoTooieRules:
     
     def clawClimberBoots(self, state: CollectionState) -> bool:
         return state.has(itemName.CLAWBTS, self.player) or state.has(itemName.PSHOES, self.player, 4)
+    
+    def dive(self, state: CollectionState) -> bool:
+        return self.hasBKMove(state, itemName.DIVE) or state.has(itemName.PSWIM, self.player, 1)
+
+    def doubleAir(self, state: CollectionState) -> bool:
+        return state.has(itemName.DAIR, self.player) or state.has(itemName.PSWIM, self.player, 2)
 
     #You cannot use bill drill without beak buster. Pressing Z in the air does nothing.
     def billDrill(self, state: CollectionState) -> bool:
@@ -4641,7 +4647,8 @@ class BanjoTooieRules:
     
     #You cannot use breegull blaster without the ground ratatat rat, pressing B does nothing.
     def breegullBash(self, state: CollectionState) -> bool:
-        return self.hasBKMove(state, itemName.GRAT) and state.has(itemName.BBASH, self.player)
+        return (self.hasBKMove(state, itemName.GRAT) and state.has(itemName.BBASH, self.player))\
+            or state.has(itemName.PBASH, self.player, 2)
     
     def longJump(self, state: CollectionState) -> bool:
         logic = True
@@ -4806,13 +4813,13 @@ class BanjoTooieRules:
     def can_dive_in_JRL(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.hasBKMove(state, itemName.DIVE) and state.has(itemName.MUMBOJR, self.player)
+            logic = self.dive(state) and state.has(itemName.MUMBOJR, self.player)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state, itemName.DIVE)
+            logic = self.dive(state)
         return logic
     
     def hfpTop(self, state: CollectionState) -> bool:

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -224,8 +224,10 @@ class BanjoTooieRules:
             locationName.CHUNK3: lambda state: self.jiggy_crushing_shed(state),
         }
 
-        self.food_stall_rules = {
-            locationName.BIGAL: lambda state: self.big_al_burgers(state)
+        self.scrit_scrat_scrut_rules = {
+            locationName.SCRUT: lambda state: self.scrut(state),
+            locationName.SCRAT: lambda state: self.scrat(state),
+            locationName.SCRIT: lambda state: self.scrit(state)
         }
 
         self.jiggy_rules = {
@@ -3780,15 +3782,15 @@ class BanjoTooieRules:
                   and (self.has_explosives(state) or self.hasBKMove(state,itemName.BBARGE))
         elif self.world.options.logic_type == 1: # normal
             return (self.longJumpToGripGrab(state) and self.hasBKMove(state, itemName.FFLIP) and self.hasBKMove(state, itemName.CLIMB) and (self.has_explosives(state) or self.hasBKMove(state, itemName.BBARGE)))\
-                or (state.has(itemName.EGGAIM, self.player) and self.grenadeEggs(state) and self.hasBKMove(state, itemName.CLIMB))\
+                or (state.has(itemName.EGGAIM, self.player) and self.grenadeEggs(state) and state.has(itemName.AMAZEOGAZE, self.player) and self.hasBKMove(state, itemName.CLIMB))\
                 or (self.has_explosives(state) and self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE))
         elif self.world.options.logic_type == 2: # advanced
             return (self.longJumpToGripGrab(state) and self.hasBKMove(state, itemName.FFLIP) and self.hasBKMove(state, itemName.CLIMB) and (self.has_explosives(state) or self.hasBKMove(state, itemName.BBARGE)))\
-                or (state.has(itemName.EGGAIM, self.player) and self.grenadeEggs(state))\
+                or (state.has(itemName.EGGAIM, self.player) and self.grenadeEggs(state) and state.has(itemName.AMAZEOGAZE, self.player))\
                 or (self.has_explosives(state) and self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE))
         elif self.world.options.logic_type == 3: # glitched
             return (self.longJumpToGripGrab(state) and self.hasBKMove(state, itemName.FFLIP) and self.hasBKMove(state, itemName.CLIMB) and (self.has_explosives(state) or self.hasBKMove(state, itemName.BBARGE)))\
-                or (state.has(itemName.EGGAIM, self.player) and self.grenadeEggs(state))\
+                or (state.has(itemName.EGGAIM, self.player) and self.grenadeEggs(state) and state.has(itemName.AMAZEOGAZE, self.player))\
                 or (self.has_explosives(state) and self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE))\
                 or (state.can_reach_region(regionName.GM, self.player) and self.humbaGGM(state) and self.canDoSmallElevation(state) and self.clockworkEggs(state)) # You can shoot a clockwork through the door from GGM.
 
@@ -5019,9 +5021,9 @@ class BanjoTooieRules:
                 honeyb = self.world.multiworld.get_location(location, self.player)
                 set_rule(honeyb, rules)
         
-        for location, rules in self.food_stall_rules.items():
-                food = self.world.multiworld.get_location(location, self.player)
-                set_rule(food, rules)
+        for location, rules in self.scrit_scrat_scrut_rules.items():
+                dinos = self.world.multiworld.get_location(location, self.player)
+                set_rule(dinos, rules)
 
         if self.world.options.victory_condition == 1:
             for location, rules in self.gametoken_rules.items():

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -596,9 +596,9 @@ class BanjoTooieRules:
             locationName.NOTEJRL16:  lambda state: self.notes_jolly(state),
             
             locationName.NOTETDL1:  lambda state: self.canDoSmallElevation(state) or self.humbaTDL(state),
-            locationName.NOTETDL10:  lambda state: self.longJump(state) or state.has(itemName.SPRINGB, self.player) or self.TDLFlightPad(state) or self.humbaTDL(state),
-            locationName.NOTETDL11:  lambda state: self.longJump(state) or state.has(itemName.SPRINGB, self.player) or self.TDLFlightPad(state) or self.humbaTDL(state),
-            locationName.NOTETDL12:  lambda state: self.longJump(state) or state.has(itemName.SPRINGB, self.player) or self.TDLFlightPad(state) or self.humbaTDL(state),
+            locationName.NOTETDL10:  lambda state: self.longJump(state) or self.springBoots(state) or self.TDLFlightPad(state) or self.humbaTDL(state),
+            locationName.NOTETDL11:  lambda state: self.longJump(state) or self.springBoots(state) or self.TDLFlightPad(state) or self.humbaTDL(state),
+            locationName.NOTETDL12:  lambda state: self.longJump(state) or self.springBoots(state) or self.TDLFlightPad(state) or self.humbaTDL(state),
             locationName.NOTETDL13:  lambda state: self.notes_river_passage(state),
             locationName.NOTETDL14:  lambda state: self.notes_river_passage(state),
             locationName.NOTETDL15:  lambda state: self.notes_river_passage(state),
@@ -748,16 +748,16 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = self.canReachSlightlyElevatedLedge(state)\
-                  and self.hasBKMove(state, itemName.SSTRIDE) and self.prison_compound_open(state)
+                  and self.stiltStride(state) and self.prison_compound_open(state)
         elif self.world.options.logic_type == 1: # normal
             logic = self.canReachSlightlyElevatedLedge(state)\
-                  and self.hasBKMove(state, itemName.SSTRIDE) and self.prison_compound_open(state)
+                  and self.stiltStride(state) and self.prison_compound_open(state)
         elif self.world.options.logic_type == 2: # advanced
             logic = self.canReachSlightlyElevatedLedge(state)\
-                  and self.hasBKMove(state, itemName.SSTRIDE) and self.prison_compound_open(state)
+                  and self.stiltStride(state) and self.prison_compound_open(state)
         elif self.world.options.logic_type == 3: # glitched
             logic = self.canReachSlightlyElevatedLedge(state)\
-                  and self.hasBKMove(state, itemName.SSTRIDE) and self.prison_compound_open(state)
+                  and self.stiltStride(state) and self.prison_compound_open(state)
         return logic
     
     def jiggy_pillars(self, state: CollectionState) -> bool:
@@ -827,7 +827,7 @@ class BanjoTooieRules:
     def jiggy_waterfall_cavern(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-          logic = (state.has(itemName.GGRAB, self.player) or self.canDoSmallElevation(state)) and self.hasBKMove(state, itemName.TTRAIN)
+          logic = (state.has(itemName.GGRAB, self.player) or self.canDoSmallElevation(state)) and self.turboTrainers(state)
         elif self.world.options.logic_type == 1: # normal
           logic = True
         elif self.world.options.logic_type == 2: # advanced
@@ -867,19 +867,19 @@ class BanjoTooieRules:
     def jiggy_waterfall(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.SPRINGB, self.player)
+            logic = self.springBoots(state)
 
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.SPRINGB, self.player) or \
+            logic = self.springBoots(state) or \
                     (self.check_solo_moves(state, itemName.GLIDE)\
                     or self.check_solo_moves(state, itemName.WWHACK) and (self.hasBKMove(state, itemName.TJUMP) or self.check_solo_moves(state, itemName.LSPRING))) and self.GM_boulders(state)            
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.SPRINGB, self.player) or \
+            logic = self.springBoots(state) or \
                     (self.check_solo_moves(state, itemName.GLIDE)\
                     or self.check_solo_moves(state, itemName.WWHACK) and (self.hasBKMove(state, itemName.TJUMP) or self.check_solo_moves(state, itemName.LSPRING))) and self.GM_boulders(state)\
                     or self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.has(itemName.SPRINGB, self.player) or \
+            logic = self.springBoots(state) or \
                     (self.check_solo_moves(state, itemName.GLIDE)\
                     or self.check_solo_moves(state, itemName.WWHACK) and (self.hasBKMove(state, itemName.TJUMP) or self.check_solo_moves(state, itemName.LSPRING))) and self.GM_boulders(state)\
                     or self.clockwork_shot(state)
@@ -1078,11 +1078,11 @@ class BanjoTooieRules:
         if self.world.options.logic_type == 0: # beginner
             logic = self.humbaWW(state) and state.has(itemName.SPLITUP, self.player) and self.hasBKMove(state, itemName.TJUMP)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.humbaWW(state) and (state.has(itemName.SPLITUP, self.player) and (self.hasBKMove(state, itemName.TJUMP) or state.has(itemName.LSPRING, self.player)) or self.hasBKMove(state, itemName.FFLIP) and (self.hasBKMove(state, itemName.TTROT) or self.hasBKMove(state, itemName.TTRAIN)))
+            logic = self.humbaWW(state) and (state.has(itemName.SPLITUP, self.player) and (self.hasBKMove(state, itemName.TJUMP) or state.has(itemName.LSPRING, self.player)) or self.hasBKMove(state, itemName.FFLIP) and (self.hasBKMove(state, itemName.TTROT) or self.turboTrainers(state)))
         elif self.world.options.logic_type == 2: # advanced
             logic = self.humbaWW(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.humbaWW(state) or (self.glitchedInfernoAccess(state) and (state.has(itemName.SPLITUP, self.player) and (self.hasBKMove(state, itemName.TJUMP) or state.has(itemName.LSPRING, self.player)) or self.hasBKMove(state, itemName.FFLIP) and (self.hasBKMove(state, itemName.TTROT) or self.hasBKMove(state, itemName.TTRAIN))))
+            logic = self.humbaWW(state) or (self.glitchedInfernoAccess(state) and (state.has(itemName.SPLITUP, self.player) and (self.hasBKMove(state, itemName.TJUMP) or state.has(itemName.LSPRING, self.player)) or self.hasBKMove(state, itemName.FFLIP) and (self.hasBKMove(state, itemName.TTROT) or self.turboTrainers(state))))
         return logic
     
     def jiggy_cactus(self, state: CollectionState) -> bool:
@@ -1328,25 +1328,25 @@ class BanjoTooieRules:
         if self.world.options.logic_type == 0: # beginner
             logic = state.has(itemName.BBLASTER, self.player) and (
                 ((self.hasBKMove(state, itemName.TJUMP) or state.has(itemName.GGRAB, self.player)) and self.hasBKMove(state, itemName.FPAD)
-                 or (state.has(itemName.EGGAIM, self.player) and self.has_explosives(state) and state.has(itemName.SPRINGB, self.player)))
+                 or (state.has(itemName.EGGAIM, self.player) and self.has_explosives(state) and self.springBoots(state)))
             )
         elif self.world.options.logic_type == 1: # normal
             logic = state.has(itemName.BBLASTER, self.player) and (
                 ((self.hasBKMove(state, itemName.TJUMP) or state.has(itemName.GGRAB, self.player)) and self.hasBKMove(state, itemName.FPAD)
-                 or (state.has(itemName.EGGAIM, self.player) and self.has_explosives(state) and state.has(itemName.SPRINGB, self.player))
-                 or (state.has(itemName.SPRINGB, self.player) and self.veryLongJump(state)))
+                 or (state.has(itemName.EGGAIM, self.player) and self.has_explosives(state) and self.springBoots(state))
+                 or (self.springBoots(state) and self.veryLongJump(state)))
             )
         elif self.world.options.logic_type == 2: # advanced
             logic = state.has(itemName.BBLASTER, self.player) and (
                 ((self.hasBKMove(state, itemName.TJUMP) or state.has(itemName.GGRAB, self.player)) and self.hasBKMove(state, itemName.FPAD)
-                 or (state.has(itemName.EGGAIM, self.player) and self.has_explosives(state) and state.has(itemName.SPRINGB, self.player))
-                 or (state.has(itemName.SPRINGB, self.player) and self.veryLongJump(state)))
+                 or (state.has(itemName.EGGAIM, self.player) and self.has_explosives(state) and self.springBoots(state))
+                 or (self.springBoots(state) and self.veryLongJump(state)))
             )
         elif self.world.options.logic_type == 3: # glitched
             logic = state.has(itemName.BBLASTER, self.player) and (
                 ((self.hasBKMove(state, itemName.TJUMP) or state.has(itemName.GGRAB, self.player)) and self.hasBKMove(state, itemName.FPAD)
-                 or (state.has(itemName.EGGAIM, self.player) and self.has_explosives(state) and state.has(itemName.SPRINGB, self.player))
-                 or (state.has(itemName.SPRINGB, self.player) and self.veryLongJump(state)))
+                 or (state.has(itemName.EGGAIM, self.player) and self.has_explosives(state) and self.springBoots(state))
+                 or (self.springBoots(state) and self.veryLongJump(state)))
             )
         return logic
 
@@ -1511,20 +1511,20 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = self.fireEggs(state) and self.iceEggs(state) and \
-                    state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.FPAD) and self.hasBKMove(state, itemName.EGGSHOOT)
+                    self.clawClimberBoots(state) and self.hasBKMove(state, itemName.FPAD) and self.hasBKMove(state, itemName.EGGSHOOT)
         elif self.world.options.logic_type == 1: # normal
             logic = self.fireEggs(state) and self.iceEggs(state) and \
-                    state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.FPAD) and self.hasBKMove(state, itemName.EGGSHOOT)
+                    self.clawClimberBoots(state) and self.hasBKMove(state, itemName.FPAD) and self.hasBKMove(state, itemName.EGGSHOOT)
         elif self.world.options.logic_type == 2: # advanced
             # In case people go for the damage boost for Chilly Willy then die before getting the jiggy, we also require Pack Whack to prevent softlocks.
             logic = self.fireEggs(state) and self.iceEggs(state) and self.hasBKMove(state, itemName.FPAD) and self.hasBKMove(state, itemName.EGGSHOOT) and \
-                    (state.has(itemName.CLAWBTS, self.player)\
+                    (self.clawClimberBoots(state)\
                      or (self.check_solo_moves(state, itemName.PACKWH) and self.hasBKMove(state, itemName.TJUMP) and self.hasBKMove(state, itemName.FLUTTER) and \
                          (self.hasBKMove(state, itemName.TTROT) or self.hasBKMove(state, itemName.FFLIP))))
         elif self.world.options.logic_type == 3: # glitched
             # In case people go for the damage boost for Chilly Willy then die before getting the jiggy, we also require Pack Whack to prevent softlocks.
             logic = self.fireEggs(state) and self.iceEggs(state) and self.hasBKMove(state, itemName.FPAD) and self.hasBKMove(state, itemName.EGGSHOOT) and \
-                    (state.has(itemName.CLAWBTS, self.player)\
+                    (self.clawClimberBoots(state)\
                      or (self.check_solo_moves(state, itemName.PACKWH) and self.hasBKMove(state, itemName.TJUMP) and self.hasBKMove(state, itemName.FLUTTER) and \
                          (self.hasBKMove(state, itemName.TTROT) or self.hasBKMove(state, itemName.FFLIP))))
         return logic
@@ -1677,25 +1677,25 @@ class BanjoTooieRules:
     def jiggy_mr_fit(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.SPRINGB, self.player) and self.check_solo_moves(state, itemName.SAPACK) and \
+            logic = self.springBoots(state) and self.check_solo_moves(state, itemName.SAPACK) and \
                     self.grow_beanstalk(state) and self.can_use_floatus(state) and self.hasBKMove(state, itemName.CLIMB)\
-                    and self.hasBKMove(state, itemName.TTRAIN)
+                    and self.turboTrainers(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = (state.has(itemName.SPRINGB, self.player) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
+            logic = (self.springBoots(state) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
                     self.grow_beanstalk(state) and self.can_use_floatus(state) and self.hasBKMove(state, itemName.CLIMB)\
-                    and (self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.HUMBACC, self.player))
+                    and (self.turboTrainers(state) or state.has(itemName.HUMBACC, self.player))
         elif self.world.options.logic_type == 2: # advanced
-            logic = (state.has(itemName.SPRINGB, self.player) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
+            logic = (self.springBoots(state) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
                     self.grow_beanstalk(state) and \
                     (self.can_use_floatus(state) or self.check_solo_moves(state, itemName.PACKWH))\
                     and self.hasBKMove(state, itemName.CLIMB)\
-                    and (self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.HUMBACC, self.player))
+                    and (self.turboTrainers(state) or state.has(itemName.HUMBACC, self.player))
         elif self.world.options.logic_type == 3: # glitched
-            logic = (state.has(itemName.SPRINGB, self.player) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
+            logic = (self.springBoots(state) or self.hasBKMove(state, itemName.FPAD)) and self.check_solo_moves(state, itemName.SAPACK) and \
                     self.grow_beanstalk(state) and \
                     (self.can_use_floatus(state) or self.check_solo_moves(state, itemName.PACKWH))\
                     and self.hasBKMove(state, itemName.CLIMB)\
-                    and (self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.HUMBACC, self.player) or self.clockworkEggs(state))
+                    and (self.turboTrainers(state) or state.has(itemName.HUMBACC, self.player) or self.clockworkEggs(state))
         return logic
     
     def jiggy_gold_pot(self, state: CollectionState) -> bool:
@@ -1930,17 +1930,17 @@ class BanjoTooieRules:
     def honeycomb_lakeside(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.hasBKMove(state, itemName.TTRAIN)
+            logic = self.turboTrainers(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state, itemName.TTRAIN) or self.TDLFlightPad(state)\
+            logic = self.turboTrainers(state) or self.TDLFlightPad(state)\
                 or (self.hasBKMove(state, itemName.TJUMP) and self.veryLongJump(state) and state.has(itemName.GGRAB, self.player))\
                 or state.has(itemName.SPLITUP, self.player)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.hasBKMove(state, itemName.TTRAIN) or self.TDLFlightPad(state) or self.clockwork_shot(state)\
+            logic = self.turboTrainers(state) or self.TDLFlightPad(state) or self.clockwork_shot(state)\
                 or (self.hasBKMove(state, itemName.TJUMP) and self.veryLongJump(state) and state.has(itemName.GGRAB, self.player))\
                 or state.has(itemName.SPLITUP, self.player)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state, itemName.TTRAIN) or self.TDLFlightPad(state) or self.clockwork_shot(state)\
+            logic = self.turboTrainers(state) or self.TDLFlightPad(state) or self.clockwork_shot(state)\
                 or (self.hasBKMove(state, itemName.TJUMP) and self.veryLongJump(state) and state.has(itemName.GGRAB, self.player))\
                 or state.has(itemName.SPLITUP, self.player)
         return logic
@@ -2153,26 +2153,26 @@ class BanjoTooieRules:
     def cheato_gm_entrance(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.SPRINGB, self.player)
+            logic = self.springBoots(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.SPRINGB, self.player) or \
+            logic = self.springBoots(state) or \
                     (self.hasBKMove(state, itemName.CLIMB) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)))\
                     or (self.GM_boulders(state) and self.check_solo_moves(state, itemName.LSPRING))\
                     or (self.GM_boulders(state) and self.check_solo_moves(state, itemName.GLIDE) and self.hasBKMove(state, itemName.TJUMP))
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.SPRINGB, self.player) or \
+            logic = self.springBoots(state) or \
                     (self.hasBKMove(state, itemName.CLIMB) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)))\
                     or (state.has(itemName.EGGAIM, self.player) and self.clockworkEggs(state))\
                     or (self.GM_boulders(state) and self.check_solo_moves(state, itemName.LSPRING))\
                     or (self.GM_boulders(state) and self.check_solo_moves(state, itemName.GLIDE) and self.hasBKMove(state, itemName.TJUMP))\
-                    or (self.GM_boulders(state) and self.hasBKMove(state, itemName.TJUMP) and self.hasBKMove(state, itemName.TTRAIN) and (self.check_solo_moves(state, itemName.WWHACK) or self.check_solo_moves(state, itemName.GLIDE)))
+                    or (self.GM_boulders(state) and self.hasBKMove(state, itemName.TJUMP) and self.turboTrainers(state) and (self.check_solo_moves(state, itemName.WWHACK) or self.check_solo_moves(state, itemName.GLIDE)))
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.has(itemName.SPRINGB, self.player) or \
+            logic = self.springBoots(state) or \
                     (self.hasBKMove(state, itemName.CLIMB) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)))\
                     or (state.has(itemName.EGGAIM, self.player) and self.clockworkEggs(state))\
                     or (self.GM_boulders(state) and self.check_solo_moves(state, itemName.LSPRING))\
                     or (self.GM_boulders(state) and self.check_solo_moves(state, itemName.GLIDE) and self.hasBKMove(state, itemName.TJUMP))\
-                    or (self.GM_boulders(state) and self.hasBKMove(state, itemName.TJUMP) and self.hasBKMove(state, itemName.TTRAIN) and (self.check_solo_moves(state, itemName.WWHACK) or self.check_solo_moves(state, itemName.GLIDE)))
+                    or (self.GM_boulders(state) and self.hasBKMove(state, itemName.TJUMP) and self.turboTrainers(state) and (self.check_solo_moves(state, itemName.WWHACK) or self.check_solo_moves(state, itemName.GLIDE)))
         return logic
     
     def cheato_waterstorage(self, state: CollectionState) -> bool:
@@ -2293,16 +2293,16 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.hasBKMove(state, itemName.DIVE)\
-                and ((self.canDoSmallElevation(state) and state.has(itemName.SPRINGB, self.player)) or self.TDLFlightPad(state))
+                and ((self.canDoSmallElevation(state) and self.springBoots(state)) or self.TDLFlightPad(state))
         elif self.world.options.logic_type == 1: # normal
             logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.hasBKMove(state, itemName.DIVE)\
-                and ((self.canDoSmallElevation(state) and state.has(itemName.SPRINGB, self.player)) or self.TDLFlightPad(state))
+                and ((self.canDoSmallElevation(state) and self.springBoots(state)) or self.TDLFlightPad(state))
         elif self.world.options.logic_type == 2: # advanced
             logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.hasBKMove(state, itemName.DIVE)\
-                and ((self.canDoSmallElevation(state) and state.has(itemName.SPRINGB, self.player)) or self.TDLFlightPad(state))
+                and ((self.canDoSmallElevation(state) and self.springBoots(state)) or self.TDLFlightPad(state))
         elif self.world.options.logic_type == 3: # glitched
             logic = state.can_reach_region(regionName.CC, self.player) and self.jiggy_dippy(state) and self.hasBKMove(state, itemName.DIVE)\
-                and ((self.canDoSmallElevation(state) and state.has(itemName.SPRINGB, self.player)) or self.TDLFlightPad(state))
+                and ((self.canDoSmallElevation(state) and self.springBoots(state)) or self.TDLFlightPad(state))
         return logic
     
     def cheato_tdlboulder(self, state: CollectionState) -> bool:
@@ -2335,17 +2335,17 @@ class BanjoTooieRules:
     def cheato_colosseum(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.CLAWBTS, self.player) and self.has_explosives(state)
+            logic = self.clawClimberBoots(state) and self.has_explosives(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.CLAWBTS, self.player) and \
+            logic = self.clawClimberBoots(state) and \
                     (self.has_explosives(state) or
                     self.check_mumbo_magic(state, itemName.MUMBOHP))
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.CLAWBTS, self.player) and \
+            logic = self.clawClimberBoots(state) and \
                     (self.has_explosives(state) or
                     self.check_mumbo_magic(state, itemName.MUMBOHP))
         elif self.world.options.logic_type == 3: # glitched
-            logic = (state.has(itemName.CLAWBTS, self.player) and (self.has_explosives(state) or self.check_mumbo_magic(state, itemName.MUMBOHP)))\
+            logic = (self.clawClimberBoots(state) and (self.has_explosives(state) or self.check_mumbo_magic(state, itemName.MUMBOHP)))\
                     or self.hfpTop(state) and self.hasBKMove(state, itemName.EGGSHOOT)
         return logic
     
@@ -2592,13 +2592,13 @@ class BanjoTooieRules:
     def jinjo_clifftop(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.CLAWBTS, self.player)
+            logic = self.clawClimberBoots(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.CLAWBTS, self.player)
+            logic = self.clawClimberBoots(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.CLAWBTS, self.player) or self.clockwork_shot(state)
+            logic = self.clawClimberBoots(state) or self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.CLIMB) or self.clockwork_shot(state)
+            logic = self.clawClimberBoots(state) and self.hasBKMove(state, itemName.CLIMB) or self.clockwork_shot(state)
         return logic
 
     def jinjo_wasteland(self, state: CollectionState) -> bool:
@@ -2681,7 +2681,7 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 3: # glitched
             logic = self.hasBKMove(state, itemName.TTROT) or self.humbaWW(state) or self.clockwork_shot(state) or state.has(itemName.SPLITUP, self.player) or\
                   ((state.has(itemName.GGRAB, self.player) or self.beakBuster(state)) and self.hasBKMove(state, itemName.CLIMB) and self.hasBKMove(state, itemName.FFLIP))\
-                  or (self.glitchedInfernoAccess(state) and self.hasBKMove(state, itemName.TTRAIN))
+                  or (self.glitchedInfernoAccess(state) and self.turboTrainers(state))
         return logic
     
     def jinjo_caveofhorror(self, state: CollectionState) -> bool:
@@ -2743,17 +2743,17 @@ class BanjoTooieRules:
     def jinjo_alcove(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.DOUBLOON, self.player, 28) and self.hasBKMove(state, itemName.TTRAIN)
+            logic = state.has(itemName.DOUBLOON, self.player, 28) and self.turboTrainers(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = (state.has(itemName.DOUBLOON, self.player, 28) and self.hasBKMove(state, itemName.TTRAIN)) or (self.has_explosives(state) and (self.check_solo_moves(state, itemName.PACKWH) or \
+            logic = (state.has(itemName.DOUBLOON, self.player, 28) and self.turboTrainers(state)) or (self.has_explosives(state) and (self.check_solo_moves(state, itemName.PACKWH) or \
                     self.check_solo_moves(state, itemName.SAPACK) or (self.check_solo_moves(state, itemName.LSPRING) and \
                     self.check_solo_moves(state, itemName.GLIDE))))
         elif self.world.options.logic_type == 2: # advanced
-            logic = (state.has(itemName.DOUBLOON, self.player, 28) and self.hasBKMove(state, itemName.TTRAIN)) or (self.has_explosives(state) and (self.check_solo_moves(state, itemName.PACKWH) or \
+            logic = (state.has(itemName.DOUBLOON, self.player, 28) and self.turboTrainers(state)) or (self.has_explosives(state) and (self.check_solo_moves(state, itemName.PACKWH) or \
                     self.check_solo_moves(state, itemName.SAPACK) or (self.check_solo_moves(state, itemName.LSPRING) and \
                     self.check_solo_moves(state, itemName.GLIDE)))) or self.hasBKMove(state, itemName.TJUMP) or self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (state.has(itemName.DOUBLOON, self.player, 28) and self.hasBKMove(state, itemName.TTRAIN)) or (self.has_explosives(state) and (self.check_solo_moves(state, itemName.PACKWH) or \
+            logic = (state.has(itemName.DOUBLOON, self.player, 28) and self.turboTrainers(state)) or (self.has_explosives(state) and (self.check_solo_moves(state, itemName.PACKWH) or \
                     self.check_solo_moves(state, itemName.SAPACK) or (self.check_solo_moves(state, itemName.LSPRING) and \
                     self.check_solo_moves(state, itemName.GLIDE)))) or self.hasBKMove(state, itemName.TJUMP) or self.clockwork_shot(state)
         return logic
@@ -2863,13 +2863,13 @@ class BanjoTooieRules:
     def jinjo_floor4(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.SPLITUP, self.player) and (self.roof_access(state) or state.has(itemName.CLAWBTS, self.player))
+            logic = state.has(itemName.SPLITUP, self.player) and (self.roof_access(state) or self.clawClimberBoots(state))
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.SPLITUP, self.player) and (self.roof_access(state) or state.has(itemName.CLAWBTS, self.player))
+            logic = state.has(itemName.SPLITUP, self.player) and (self.roof_access(state) or self.clawClimberBoots(state))
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.SPLITUP, self.player) and (self.roof_access(state) or state.has(itemName.CLAWBTS, self.player))
+            logic = state.has(itemName.SPLITUP, self.player) and (self.roof_access(state) or self.clawClimberBoots(state))
         elif self.world.options.logic_type == 3: # glitched
-            logic = (state.has(itemName.SPLITUP, self.player) or self.egg_barge(state)) and (self.roof_access(state) or state.has(itemName.CLAWBTS, self.player))
+            logic = (state.has(itemName.SPLITUP, self.player) or self.egg_barge(state)) and (self.roof_access(state) or self.clawClimberBoots(state))
         return logic
     
     def jinjo_wasteplant(self, state: CollectionState) -> bool:
@@ -3009,18 +3009,18 @@ class BanjoTooieRules:
             logic = state.has(itemName.SPLITUP, self.player) and self.springPad(state)
         elif self.world.options.logic_type == 1: # normal
             logic = state.has(itemName.SPLITUP, self.player) and self.springPad(state)\
-                    or (state.has(itemName.SPRINGB, self.player) and self.billDrill(state))\
+                    or (self.springBoots(state) and self.billDrill(state))\
                     or self.check_solo_moves(state, itemName.LSPRING)
                      
         elif self.world.options.logic_type == 2: # advanced
             logic = state.has(itemName.SPLITUP, self.player) and self.springPad(state)\
                     or self.clockwork_shot(state)\
-                    or (state.has(itemName.SPRINGB, self.player) and self.billDrill(state))\
+                    or (self.springBoots(state) and self.billDrill(state))\
                     or self.check_solo_moves(state, itemName.LSPRING)
         elif self.world.options.logic_type == 3: # glitched
             logic = state.has(itemName.SPLITUP, self.player) and self.springPad(state)\
                     or self.clockwork_shot(state)\
-                    or (state.has(itemName.SPRINGB, self.player) and self.billDrill(state))\
+                    or (self.springBoots(state) and self.billDrill(state))\
                     or self.check_solo_moves(state, itemName.LSPRING)
         return logic
 
@@ -3093,17 +3093,17 @@ class BanjoTooieRules:
     def treble_gi(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.SPLITUP, self.player) and state.has(itemName.CLAWBTS, self.player)
+            logic = state.has(itemName.SPLITUP, self.player) and self.clawClimberBoots(state)
         elif self.world.options.logic_type == 1: # normal
-            logic =  state.has(itemName.SPLITUP, self.player) and state.has(itemName.CLAWBTS, self.player)\
+            logic =  state.has(itemName.SPLITUP, self.player) and self.clawClimberBoots(state)\
                     or self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE) and\
                         (self.check_solo_moves(state, itemName.WWHACK) or state.has(itemName.EGGAIM, self.player))
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.SPLITUP, self.player) and (state.has(itemName.CLAWBTS, self.player) or self.clockwork_shot(state))\
+            logic = state.has(itemName.SPLITUP, self.player) and (self.clawClimberBoots(state) or self.clockwork_shot(state))\
                     or self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE) and\
                         (self.check_solo_moves(state, itemName.WWHACK) or state.has(itemName.EGGAIM, self.player))
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.has(itemName.SPLITUP, self.player) and (state.has(itemName.CLAWBTS, self.player) or self.clockwork_shot(state))\
+            logic = state.has(itemName.SPLITUP, self.player) and (self.clawClimberBoots(state) or self.clockwork_shot(state))\
                     or self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE) and\
                         (self.check_solo_moves(state, itemName.WWHACK) or state.has(itemName.EGGAIM, self.player))
         return logic
@@ -3421,13 +3421,13 @@ class BanjoTooieRules:
             logic = self.can_access_gi_fl1_2fl2(state)\
                 or (state.has(itemName.GGRAB, self.player) and self.hasBKMove(state, itemName.CLIMB) and self.hasBKMove(state, itemName.FFLIP))
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.CLAWBTS, self.player)\
+            logic = self.clawClimberBoots(state)\
                     or (state.has(itemName.GGRAB, self.player) and self.hasBKMove(state, itemName.CLIMB) and self.hasBKMove(state, itemName.FFLIP))\
                     or self.check_solo_moves(state, itemName.PACKWH) and self.hasBKMove(state, itemName.TJUMP) and self.hasBKMove(state, itemName.CLIMB)\
                     or self.check_solo_moves(state, itemName.LSPRING)\
                     or self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.has(itemName.CLAWBTS, self.player)\
+            logic = self.clawClimberBoots(state)\
                     or (state.has(itemName.GGRAB, self.player) and self.hasBKMove(state, itemName.CLIMB) and self.hasBKMove(state, itemName.FFLIP))\
                     or self.check_solo_moves(state, itemName.PACKWH) and self.hasBKMove(state, itemName.TJUMP) and self.hasBKMove(state, itemName.CLIMB)\
                     or self.check_solo_moves(state, itemName.LSPRING)\
@@ -3443,11 +3443,11 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 2: # advanced
             logic = (self.hasBKMove(state, itemName.CLIMB) or (self.has_explosives(state) and self.canDoSmallElevation(state)))\
                     or self.clockwork_shot(state)\
-                    or state.has(itemName.CLAWBTS, self.player) and self.extremelyLongJump(state)
+                    or self.clawClimberBoots(state) and self.extremelyLongJump(state)
         elif self.world.options.logic_type == 3: # glitched
             logic = (self.hasBKMove(state, itemName.CLIMB) or (self.has_explosives(state) and self.canDoSmallElevation(state)))\
                     or self.clockwork_shot(state)\
-                    or state.has(itemName.CLAWBTS, self.player) and self.extremelyLongJump(state)
+                    or self.clawClimberBoots(state) and self.extremelyLongJump(state)
         return logic
     
     def notes_short_stack(self, state: CollectionState) -> bool:
@@ -3516,12 +3516,12 @@ class BanjoTooieRules:
                     or self.notes_ccl_high(state)
         elif self.world.options.logic_type == 2: # advanced
             logic = (self.hasBKMove(state, itemName.CLIMB) and self.check_solo_moves(state, itemName.SAPACK))\
-                    or (state.has(itemName.SPRINGB, self.player))\
+                    or (self.springBoots(state))\
                     or self.notes_ccl_high(state)\
                     or self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
             logic = (self.hasBKMove(state, itemName.CLIMB) and self.check_solo_moves(state, itemName.SAPACK))\
-                    or (state.has(itemName.SPRINGB, self.player))\
+                    or (self.springBoots(state))\
                     or self.notes_ccl_high(state)\
                     or self.clockwork_shot(state)
         return logic
@@ -3591,9 +3591,9 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 1: # normal
             logic = self.check_notes(state, 85) and self.hasBKMove(state, itemName.FFLIP)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.check_notes(state, 85) and (self.hasBKMove(state, itemName.FFLIP) or self.hasBKMove(state, itemName.TTRAIN))
+            logic = self.check_notes(state, 85) and (self.hasBKMove(state, itemName.FFLIP) or self.turboTrainers(state))
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.check_notes(state, 85) and (self.hasBKMove(state, itemName.FFLIP) or self.hasBKMove(state, itemName.TTRAIN))
+            logic = self.check_notes(state, 85) and (self.hasBKMove(state, itemName.FFLIP) or self.turboTrainers(state))
         return logic
     
     def silo_spring(self, state:CollectionState) -> bool:
@@ -3782,31 +3782,31 @@ class BanjoTooieRules:
         
     def tdl_top(self, state: CollectionState) -> bool:
         if self.world.options.logic_type == 0: # beginner
-            return state.has(itemName.SPRINGB, self.player)
+            return self.springBoots(state)
         elif self.world.options.logic_type == 1: # normal
-            return state.has(itemName.SPRINGB, self.player)
+            return self.springBoots(state)
         elif self.world.options.logic_type == 2: # advanced
-            return (state.has(itemName.SPRINGB, self.player) or self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE))
+            return (self.springBoots(state) or self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE))
         elif self.world.options.logic_type == 3: # glitched
-            return (state.has(itemName.SPRINGB, self.player) or \
+            return (self.springBoots(state) or \
                     self.check_solo_moves(state, itemName.LSPRING) and self.check_solo_moves(state, itemName.GLIDE) or\
                     (self.hasBKMove(state, itemName.FPAD) and (self.hasBKMove(state, itemName.BBOMB) or\
                     self.clockworkWarp(state))))
         
     def smuggle_food(self, state: CollectionState) -> bool:
-        return state.has(itemName.CLAWBTS, self.player)
+        return self.clawClimberBoots(state)
 
     def oogle_boogles_open(self, state) -> bool:
         return self.humbaTDL(state) and self.mumboTDL(state)
 
     def enter_GI(self, state: CollectionState) -> bool:
-        return self.can_beat_king_coal(state) or state.has(itemName.CLAWBTS, self.player)
+        return self.can_beat_king_coal(state) or self.clawClimberBoots(state)
 
     def GI_front_door(self, state: CollectionState) -> bool:
         return self.enter_GI(state) and state.has(itemName.SPLITUP, self.player)
 
     def can_reach_GI_2F(self, state: CollectionState) -> bool:
-        return state.has(itemName.CLAWBTS, self.player) or \
+        return self.clawClimberBoots(state) or \
                (self.GI_front_door(state) and
                 self.check_solo_moves(state, itemName.LSPRING) and
                 self.check_solo_moves(state, itemName.GLIDE) and
@@ -3860,15 +3860,15 @@ class BanjoTooieRules:
     def jiggy_clinkers(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
+            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and self.clawClimberBoots(state) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
+            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and self.clawClimberBoots(state) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
+            logic = self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP) and self.clawClimberBoots(state) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 3: # glitched
             logic = ((self.mumboGI(state) and self.hasBKMove(state, itemName.TJUMP))\
                      or ((self.breegullBash(state) or (self.grenadeEggs(state) and state.has(itemName.EGGAIM, self.player))) and self.hasBKMove(state, itemName.CLIMB)))\
-                  and state.has(itemName.CLAWBTS, self.player) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
+                  and self.clawClimberBoots(state) and state.has(itemName.BBLASTER, self.player) and self.hasBKMove(state, itemName.CLIMB)
         return logic
 
     def can_use_battery(self, state: CollectionState) -> bool:
@@ -4099,13 +4099,13 @@ class BanjoTooieRules:
     def quag_to_CK(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.CLIMB) and self.ck_jiggy(state)
+            logic = self.clawClimberBoots(state) and self.hasBKMove(state, itemName.CLIMB) and self.ck_jiggy(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.CLIMB) and self.ck_jiggy(state)
+            logic = self.clawClimberBoots(state) and self.hasBKMove(state, itemName.CLIMB) and self.ck_jiggy(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.CLIMB) and self.ck_jiggy(state)
+            logic = self.clawClimberBoots(state) and self.hasBKMove(state, itemName.CLIMB) and self.ck_jiggy(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state, itemName.CLIMB) and (state.has(itemName.CLAWBTS, self.player) or \
+            logic = self.hasBKMove(state, itemName.CLIMB) and (self.clawClimberBoots(state) or \
                      (self.grenadeEggs(state) and self.clockworkEggs(state) and state.has(itemName.EGGAIM, self.player) and self.hasBKMove(state, itemName.EGGSHOOT)))
         return logic
 
@@ -4251,29 +4251,29 @@ class BanjoTooieRules:
         if self.world.options.logic_type == 0: # beginner
             logic = False
         elif self.world.options.logic_type == 1: # normal
-            logic = state.has(itemName.CLAWBTS, self.player) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)) and self.hasBKMove(state, itemName.CLIMB)
+            logic = self.clawClimberBoots(state) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)) and self.hasBKMove(state, itemName.CLIMB)
         elif self.world.options.logic_type == 2: # advanced
-            logic = state.has(itemName.CLAWBTS, self.player) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)) and\
+            logic = self.clawClimberBoots(state) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)) and\
                     (self.hasBKMove(state, itemName.CLIMB) or self.extremelyLongJump(state))
         elif self.world.options.logic_type == 3: # glitched
-            logic = state.has(itemName.CLAWBTS, self.player) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)) and\
+            logic = self.clawClimberBoots(state) and (self.hasBKMove(state, itemName.FLUTTER) or self.hasBKMove(state, itemName.ARAT)) and\
                     (self.hasBKMove(state, itemName.CLIMB) or self.extremelyLongJump(state))
         return logic
     
     def can_access_gi_fl1_2fl2(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = (state.has(itemName.CLAWBTS, self.player) and (self.springPad(state) or self.check_solo_moves(state, itemName.LSPRING)))
+            logic = (self.clawClimberBoots(state) and (self.springPad(state) or self.check_solo_moves(state, itemName.LSPRING)))
         elif self.world.options.logic_type == 1: # normal
-            logic = (state.has(itemName.CLAWBTS, self.player) and (self.springPad(state) or self.check_solo_moves(state, itemName.LSPRING))) or self.check_solo_moves(state, itemName.LSPRING) and \
+            logic = (self.clawClimberBoots(state) and (self.springPad(state) or self.check_solo_moves(state, itemName.LSPRING))) or self.check_solo_moves(state, itemName.LSPRING) and \
                     self.check_solo_moves(state, itemName.GLIDE) and (self.check_solo_moves(state, itemName.WWHACK) or \
                     state.has(itemName.EGGAIM, self.player))
         elif self.world.options.logic_type == 2: # advanced
-            logic = (state.has(itemName.CLAWBTS, self.player) and (self.springPad(state) or self.check_solo_moves(state, itemName.LSPRING))) or self.check_solo_moves(state, itemName.LSPRING) and \
+            logic = (self.clawClimberBoots(state) and (self.springPad(state) or self.check_solo_moves(state, itemName.LSPRING))) or self.check_solo_moves(state, itemName.LSPRING) and \
                     self.check_solo_moves(state, itemName.GLIDE) and (self.check_solo_moves(state, itemName.WWHACK) or \
                     state.has(itemName.EGGAIM, self.player))
         elif self.world.options.logic_type == 3: # glitched
-            logic = (state.has(itemName.CLAWBTS, self.player) and (self.springPad(state) or self.check_solo_moves(state, itemName.LSPRING))) or self.check_solo_moves(state, itemName.LSPRING) and \
+            logic = (self.clawClimberBoots(state) and (self.springPad(state) or self.check_solo_moves(state, itemName.LSPRING))) or self.check_solo_moves(state, itemName.LSPRING) and \
                     self.check_solo_moves(state, itemName.GLIDE) and (self.check_solo_moves(state, itemName.WWHACK) or \
                     state.has(itemName.EGGAIM, self.player))
         return logic
@@ -4289,7 +4289,7 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 3: # glitched
             logic = self.breegullBash(state) and self.hasBKMove(state, itemName.CLIMB)\
                     or self.hasBKMove(state, itemName.CLIMB) and self.has_explosives(state) and state.has(itemName.EGGAIM, self.player) and\
-                        (state.has(itemName.SPRINGB, self.player) or self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) or state.has(itemName.SPLITUP, self.player) and self.roof_access(state))
+                        (self.springBoots(state) or self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) or state.has(itemName.SPLITUP, self.player) and self.roof_access(state))
         return logic
     
     def F2_to_F1(self, state: CollectionState) -> bool:
@@ -4308,32 +4308,32 @@ class BanjoTooieRules:
     def can_access_gi_fl2_2fl3all(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = (state.has(itemName.GGRAB, self.player) and state.has(itemName.CLAWBTS, self.player)) or self.check_humba_magic(state, itemName.HUMBAGI)
+            logic = (state.has(itemName.GGRAB, self.player) and self.clawClimberBoots(state)) or self.check_humba_magic(state, itemName.HUMBAGI)
         elif self.world.options.logic_type == 1: # normal
-            logic = (self.check_humba_magic(state, itemName.HUMBAGI) and state.has(itemName.CLAWBTS, self.player))\
+            logic = (self.check_humba_magic(state, itemName.HUMBAGI) and self.clawClimberBoots(state))\
                 or self.check_solo_moves(state, itemName.LSPRING)
         elif self.world.options.logic_type == 2: # advanced
-            logic = (self.check_humba_magic(state, itemName.HUMBAGI) and state.has(itemName.CLAWBTS, self.player))\
+            logic = (self.check_humba_magic(state, itemName.HUMBAGI) and self.clawClimberBoots(state))\
                 or self.check_solo_moves(state, itemName.LSPRING)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.check_humba_magic(state, itemName.HUMBAGI) and state.has(itemName.CLAWBTS, self.player))\
+            logic = (self.check_humba_magic(state, itemName.HUMBAGI) and self.clawClimberBoots(state))\
                 or self.check_solo_moves(state, itemName.LSPRING)
         return logic
     
     def F2_to_F3(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = (self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) and state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.CLIMB))\
+            logic = (self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) and self.clawClimberBoots(state) and self.hasBKMove(state, itemName.CLIMB))\
                     or self.check_humba_magic(state, itemName.HUMBAGI)
         elif self.world.options.logic_type == 1: # normal
-            logic = ((self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) or self.veryLongJump(state)) and state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.CLIMB))\
+            logic = ((self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) or self.veryLongJump(state)) and self.clawClimberBoots(state) and self.hasBKMove(state, itemName.CLIMB))\
                     or self.check_humba_magic(state, itemName.HUMBAGI) or self.check_solo_moves(state, itemName.LSPRING)
         elif self.world.options.logic_type == 2: # advanced
-            logic = ((self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) or self.veryLongJump(state)) and state.has(itemName.CLAWBTS, self.player) and self.hasBKMove(state, itemName.CLIMB))\
+            logic = ((self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) or self.veryLongJump(state)) and self.clawClimberBoots(state) and self.hasBKMove(state, itemName.CLIMB))\
                     or self.check_humba_magic(state, itemName.HUMBAGI) or self.check_solo_moves(state, itemName.LSPRING)
         elif self.world.options.logic_type == 3: # glitched
             logic = ((self.hasBKMove(state, itemName.FFLIP) and state.has(itemName.GGRAB, self.player) or self.veryLongJump(state))\
-                        and state.has(itemName.CLAWBTS, self.player)\
+                        and self.clawClimberBoots(state)\
                         and (self.hasBKMove(state, itemName.CLIMB) or (self.grenadeEggs(state) and self.hasBKMove(state, itemName.EGGSHOOT) and self.hasBKMove(state, itemName.FFLIP) and self.beakBuster(state))))\
                     or self.check_humba_magic(state, itemName.HUMBAGI)\
                     or self.check_solo_moves(state, itemName.LSPRING)
@@ -4442,7 +4442,7 @@ class BanjoTooieRules:
     
     def can_leave_GI_from_inside(self, state:CollectionState) -> bool:
         return self.has_train_access(state, "GI") and (state.has(itemName.SPLITUP, self.player) or \
-               state.has(itemName.CLAWBTS, self.player))
+               self.clawClimberBoots(state))
 
     def WW_train_station(self, state) -> bool:
         return self.can_beat_king_coal(state) and \
@@ -4621,6 +4621,18 @@ class BanjoTooieRules:
     
     def beakBuster(self, state: CollectionState) -> bool:
         return self.hasBKMove(state, itemName.BBUST) or state.has(itemName.PBBUST, self.player)
+    
+    def stiltStride(self, state: CollectionState) -> bool:
+        return self.hasBKMove(state, itemName.SSTRIDE) or state.has(itemName.PSHOES, self.player, 1)
+    
+    def turboTrainers(self, state: CollectionState) -> bool:
+        return self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.PSHOES, self.player, 2)
+    
+    def springBoots(self, state: CollectionState) -> bool:
+        return state.has(itemName.SPRINGB, self.player) or state.has(itemName.PSHOES, self.player, 3)
+    
+    def clawClimberBoots(self, state: CollectionState) -> bool:
+        return state.has(itemName.CLAWBTS, self.player) or state.has(itemName.PSHOES, self.player, 4)
 
     #You cannot use bill drill without beak buster. Pressing Z in the air does nothing.
     def billDrill(self, state: CollectionState) -> bool:
@@ -4670,11 +4682,11 @@ class BanjoTooieRules:
         if self.world.options.logic_type == 0: # beginner
             logic = self.hasBKMove(state, itemName.TTROT)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.hasBKMove(state, itemName.TTROT) or self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.SPRINGB, self.player)
+            logic = self.hasBKMove(state, itemName.TTROT) or self.turboTrainers(state) or self.springBoots(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.hasBKMove(state, itemName.TTROT) or self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.SPRINGB, self.player)
+            logic = self.hasBKMove(state, itemName.TTROT) or self.turboTrainers(state) or self.springBoots(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.hasBKMove(state, itemName.TTROT) or self.hasBKMove(state, itemName.TTRAIN) or state.has(itemName.SPRINGB, self.player)
+            logic = self.hasBKMove(state, itemName.TTROT) or self.turboTrainers(state) or self.springBoots(state)
         return logic
     
     def humbaWW(self, state: CollectionState) -> bool:
@@ -4714,7 +4726,7 @@ class BanjoTooieRules:
     def mumboTDL(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = ((self.canDoSmallElevation(state) and self.hasBKMove(state, itemName.SSTRIDE)) or self.TDLFlightPad(state))\
+            logic = ((self.canDoSmallElevation(state) and self.stiltStride(state)) or self.TDLFlightPad(state))\
                      and state.has(itemName.MUMBOTD, self.player)
         elif self.world.options.logic_type == 1: # normal
             logic = (self.canDoSmallElevation(state) or self.TDLFlightPad(state)) and state.has(itemName.MUMBOTD, self.player)
@@ -4761,15 +4773,15 @@ class BanjoTooieRules:
     def TDLFlightPad(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.can_beat_terry(state) and state.has(itemName.SPRINGB, self.player) and self.hasBKMove(state, itemName.FPAD)
+            logic = self.can_beat_terry(state) and self.springBoots(state) and self.hasBKMove(state, itemName.FPAD)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.can_beat_terry(state) and ((state.has(itemName.SPRINGB, self.player) and self.hasBKMove(state, itemName.FPAD))\
+            logic = self.can_beat_terry(state) and ((self.springBoots(state) and self.hasBKMove(state, itemName.FPAD))\
                     or (self.hasBKMove(state, itemName.TTROT) and self.hasBKMove(state, itemName.FLUTTER)))
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.can_beat_terry(state) and ((state.has(itemName.SPRINGB, self.player) and self.hasBKMove(state, itemName.FPAD))\
+            logic = self.can_beat_terry(state) and ((self.springBoots(state) and self.hasBKMove(state, itemName.FPAD))\
                     or (self.hasBKMove(state, itemName.TTROT) and self.hasBKMove(state, itemName.FLUTTER)))
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.can_beat_terry(state) and ((state.has(itemName.SPRINGB, self.player) and self.hasBKMove(state, itemName.FPAD))\
+            logic = self.can_beat_terry(state) and ((self.springBoots(state) and self.hasBKMove(state, itemName.FPAD))\
                     or (self.hasBKMove(state, itemName.TTROT) and self.hasBKMove(state, itemName.FLUTTER)))
         return logic
     

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -224,6 +224,10 @@ class BanjoTooieRules:
             locationName.CHUNK3: lambda state: self.jiggy_crushing_shed(state),
         }
 
+        self.food_stall_rules = {
+            locationName.BIGAL: lambda state: self.big_al_burgers(state)
+        }
+
         self.jiggy_rules = {
             #Mayahem Temple Jiggies
             locationName.JIGGYMT1:  lambda state: self.jiggy_targitzan(state),
@@ -4876,6 +4880,18 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 3: # glitched
             logic = self.hasBKMove(state, itemName.FPAD) and (self.hasBKMove(state, itemName.CLIMB) or self.check_solo_moves(state, itemName.LSPRING))
         return logic
+    
+    def big_al_burgers(self, state:CollectionState) -> bool:
+        logic = True
+        if self.world.options.logic_type == 0: # beginner
+            logic = self.hasBKMove(state, itemName.TJUMP)
+        elif self.world.options.logic_type == 1: # normal
+            logic = self.hasBKMove(state, itemName.TJUMP) or self.check_solo_moves(state, itemName.LSPRING) or self.check_solo_moves(state, itemName.GLIDE)
+        elif self.world.options.logic_type == 2: # advanced
+            logic = self.hasBKMove(state, itemName.TJUMP) or self.check_solo_moves(state, itemName.LSPRING) or self.check_solo_moves(state, itemName.GLIDE)
+        elif self.world.options.logic_type == 3: # glitched
+            logic = self.hasBKMove(state, itemName.TJUMP) or self.check_solo_moves(state, itemName.LSPRING) or self.check_solo_moves(state, itemName.GLIDE)
+        return logic
 
     def set_rules(self) -> None:
 
@@ -4982,6 +4998,10 @@ class BanjoTooieRules:
             for location, rules in self.honeyb_rewards_rules.items():
                 honeyb = self.world.multiworld.get_location(location, self.player)
                 set_rule(honeyb, rules)
+        
+        for location, rules in self.food_stall_rules.items():
+                food = self.world.multiworld.get_location(location, self.player)
+                set_rule(food, rules)
 
         if self.world.options.victory_condition == 1:
             for location, rules in self.gametoken_rules.items():

--- a/worlds/banjo_tooie/WorldOrder.py
+++ b/worlds/banjo_tooie/WorldOrder.py
@@ -19,6 +19,8 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
             world.randomize_worlds = passthrough['world_order']
             world.randomize_order = passthrough['world_keys']
             world.worlds_randomized = bool(passthrough['worlds'] == 'true') 
+            world.starting_egg = passthrough['starting_egg']
+            world.starting_attack = passthrough['starting_attack']
     else:
         if world.options.randomize_worlds and world.options.randomize_moves == True and \
         world.options.skip_puzzles == True:

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -182,7 +182,7 @@ class BanjoTooieWorld(World):
                         if self.options.randomize_bk_moves.value == 1: # 2 moves won't be added to the pool
                             for i in range(2):
                                 itempool += [self.create_item(name)]
-                        if self.options.randomize_bk_moves.value == 0: # No moves added, fills for the Jiggy Chunks, goggles, & food stalls
+                        if self.options.randomize_bk_moves.value == 0: # No moves added, fills for the Jiggy Chunks, Dino Kids
                             for i in range(6):
                                 itempool += [self.create_item(name)]
                     #end of none qty logic

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -599,8 +599,12 @@ class BanjoTooieWorld(World):
         btoptions['logic_type'] = int(self.options.logic_type.value)
         # btoptions['warp_traps'] = int(self.options.warp_traps.value)
         btoptions['skip_klungo'] = "true" if self.options.skip_klungo == 1 else "false"
-        btoptions['progressive_beak_buster'] = "true" if self.options.randomize_honeycombs == 1 else "false"
+        btoptions['progressive_beak_buster'] = "true" if self.options.progressive_beak_buster == 1 else "false"
         btoptions['egg_behaviour'] = int(self.options.egg_behaviour.value)
+        btoptions['progressive_shoes'] = "true" if self.options.progressive_shoes == 1 else "false"
+        btoptions['progressive_water_training'] = "true" if self.options.progressive_water_training == 1 else "false"
+        btoptions['progressive_bash_attack'] = "true" if self.options.progressive_bash_attack == 1 else "false"
+
         btoptions['starting_egg'] = int(self.starting_egg)
         btoptions['starting_attack'] = int(self.starting_attack)
 

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -103,7 +103,8 @@ class BanjoTooieWorld(World):
         banjoItem = all_item_table.get(itemname)
         if banjoItem.type == 'progress':
             if banjoItem.btid == 1230515:
-                if self.jiggy_counter > max(self.randomize_worlds.values()) and self.options.exceeding_items_filler.value == True:
+                maxJiggy = max(self.randomize_worlds.values()) if self.randomize_worlds else 70
+                if self.jiggy_counter > maxJiggy and self.options.exceeding_items_filler.value == True:
                     item_classification = ItemClassification.filler
                 else:
                     item_classification = ItemClassification.progression

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -281,6 +281,13 @@ class BanjoTooieWorld(World):
             return False
         if self.options.egg_behaviour.value == 1 and item.code == self.starting_egg: #Already has this egg in inventory
             return False
+        
+        if self.options.progressive_shoes.value == True and (item.code == 1230826 or item.code == 1230821 \
+            or item.code == 1230768 or item.code == 1230773):
+            return False
+        if item.code == 1230830 and self.options.progressive_shoes.value == False:
+            return False
+
         if self.options.randomize_bk_moves.value != 0 and item.code == self.starting_attack: #Already has this attack in inventory
             return False
 
@@ -306,7 +313,8 @@ class BanjoTooieWorld(World):
             raise ValueError("You cannot have Randomize Starting Egg without randomizing moves and randomizing BK moves")
         elif self.options.egg_behaviour.value == 2 and (self.options.randomize_moves == False):
             raise ValueError("You cannot have progressive Eggs without randomizing moves")
-
+        if self.options.progressive_shoes.value == True and (self.options.randomize_bk_moves.value == False or self.options.randomize_moves == False):
+            raise ValueError("You cannot have progressive Shoes without randomizing moves and randomizing BK moves")
         if self.options.egg_behaviour.value == 1:
             eggs = list([itemName.BEGG, itemName.FEGGS, itemName.GEGGS, itemName.IEGGS, itemName.CEGGS])
             random.shuffle(eggs)

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -52,6 +52,7 @@ class BanjoTooieWorld(World):
     # item_name_to_id = {name: data.btid for name, data in all_item_table.items()}
     item_name_to_id = {}
     starting_egg: int
+    starting_attack: int
 
     for name, data in all_item_table.items():
         if data.btid is None:  # Skip Victory Item
@@ -256,7 +257,7 @@ class BanjoTooieWorld(World):
         if item.code in range(1230799, 1230805) and self.options.randomize_stop_n_swap == False:
             return False
 
-        if item.code in range(1230810, 1230823) and self.options.randomize_bk_moves.value == 0:
+        if item.code in range(1230810, 1230828) and self.options.randomize_bk_moves.value == 0:
             return False
         elif (item.code == 1230815 or item.code == 1230816) and self.options.randomize_bk_moves.value == 1: # talon trot and tall jump not in pool
             return False
@@ -268,7 +269,7 @@ class BanjoTooieWorld(World):
         
         if self.options.progressive_beak_buster.value == True and (item.code == 1230820 or item.code == 1230757):
             return False
-        if item.code == 1230824 and self.options.progressive_beak_buster.value == False:
+        if item.code == 1230828 and self.options.progressive_beak_buster.value == False:
             return False
         
         if self.options.egg_behaviour.value != 1 and item.code == 1230823: #remove blue eggs in pool
@@ -276,9 +277,11 @@ class BanjoTooieWorld(World):
         if self.options.egg_behaviour.value == 2 and (item.code == 1230756 or item.code == 1230759 or item.code == 1230763 \
             or item.code == 1230767):
             return False
-        if item.code == 1230825 and self.options.egg_behaviour.value != 2:
+        if item.code == 1230829 and self.options.egg_behaviour.value != 2:
             return False
         if self.options.egg_behaviour.value == 1 and item.code == self.starting_egg: #Already has this egg in inventory
+            return False
+        if self.options.randomize_bk_moves.value != 0 and item.code == self.starting_attack: #Already has this attack in inventory
             return False
 
         return True
@@ -316,6 +319,13 @@ class BanjoTooieWorld(World):
             self.multiworld.push_precollected(starting_egg)
             banjoItem = all_item_table.get(itemName.BEGG)
             self.starting_egg = banjoItem.btid
+        if self.options.randomize_bk_moves.value != 0:
+            base_attacks = list([itemName.BBARGE, itemName.ARAT, itemName.GRAT, itemName.ROLL, itemName.EGGSHOOT])
+            random.shuffle(base_attacks)
+            starting_attack = self.create_item(base_attacks[0])
+            self.multiworld.push_precollected(starting_attack)
+            banjoItem = all_item_table.get(base_attacks[0])
+            self.starting_attack = banjoItem.btid
         WorldRandomize(self)
 
     def set_rules(self) -> None:
@@ -563,6 +573,7 @@ class BanjoTooieWorld(World):
         btoptions['progressive_beak_buster'] = "true" if self.options.randomize_honeycombs == 1 else "false"
         btoptions['egg_behaviour'] = int(self.options.egg_behaviour.value)
         btoptions['starting_egg'] = int(self.starting_egg)
+        btoptions['starting_attack'] = int(self.starting_attack)
 
         return btoptions
 

--- a/yaml-template/template.yaml
+++ b/yaml-template/template.yaml
@@ -37,7 +37,7 @@ Banjo-Tooie:
   randomize_bk_moves: 0
 
   # Beak Buster -> Bill Drill Progression
-  progressive_beak_buster: 'true'
+  progressive_beak_buster: 'false'
 
   # Change how Eggs behave in Banjo-Tooie
   # 0: Default (Start with Blue Eggs, get other eggs randomly in AP)

--- a/yaml-template/template.yaml
+++ b/yaml-template/template.yaml
@@ -45,6 +45,15 @@ Banjo-Tooie:
   # 2: Progressive Eggs (Blue -> Fire -> Grenade -> Ice -> Clockwork)
   egg_behaviour: 0
 
+  # Stilt Stride -> Turbo Trainers -> Spring Boots -> Claw Climbers
+  progressive_shoes: 'false'
+
+  # Dive -> Double Air -> Fast Swimming
+  progressive_water_training: 'true'
+
+  # Ground Rat-a-tat Rap -> Breegull Bash
+  progressive_bash_attack: 'true'
+
   randomize_jinjos: 'true'
 
   # Prevent item types from being shuffled onto jinjo checks


### PR DESCRIPTION
# 2.1-beta
 - The Last 4 BK Moves are in the pool:
    - Ground Rat-a-tat Rap
    - Stilt Stride
    - Beak Barge
    - Beak Bomb
 - 3 additional check locations:
    - Goggles (Amaze-O-Gaze)
    - Scrut (Scrotty's Kid)
    - Scrat (Scrotty's Kid)
    - Scrit (Scrotty's Kid)
 - New item in the Pool: Amaze-O-Gaze
 - When you start a seed with BK Moves randomized, you start with 1 random attack:
    - Egg Shoot
    - Egg aim
    - Beak Barge
    - Roll
    - Air Rat-a-tat Rap
    - Ground Rat-a-tat Rap (only in advanced and glitched logic)
    - Beak Buster (only in advanced and glitched logic)
 - New Options:
   - Progressive Shoes (Stilt Stride -> Turbo Trainers -> Spring Boots -> Claw Climbers)
   - Progressive Water Training (Dive -> Double Air -> Faster Swimming)
   - Progressive Bash Attack (Ground Rat-a-tat Rap -> Breegull Bash)
 - 60 FPS Toggle - Hit L + Start in-game to increase the in-game clock to run 60 FPS instead of 30 (may affect CPU performance)
 - Logic fixes:
   - Pillars Jiggy: the clockwork shot is now in the advanced and glitched logic.
   - Jade Snake Grove Access: requires beak bomb if going over the door, in glitched logic.
   - Fix Prospector Boulder
   - Detonator access: you can tag the Humba warp pad using a clockwork, in advanced and glitched logic.
   - GGM Jail Jinjo: Shooting a clockwork through the wall is now part of glitched logic.
   - Scrotty Jiggy: The 3 kids have been separated into their own logic, which may have some slight side-effects.
   - Egg barges (glitch): can now be only done with blue, fire and ice eggs.
   - Saucer of Perl logic modified to also require Amaze-O-Gaze for certain tricks