### PR TITLE
Pre alpha

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,16 @@
+# 3.1.3-beta
+ - Logic fixes:
+  - Atlantis access: fixed dumb mistake that required egg aim or third person egg shooting to reach atlantis, in beginner and normal logic.
+  - JRL Pipe Honeycomb: if using leg spring, wing whack is no longer required. Advanced and glitched logic can shoot a clockwork to the honeycomb.
+  - HFP to JRL: Shack Pack can be used to dive in the pool, in HFP.
+  - Icicle Grotto Jinjo: needs tall jump for beginner logic.
+  - HFP: the access to lower icy side and the top of HFP now use the same logic, since there's the tunnel behind the icy side train switch that was overlooked. Also, split up is no longer an option to reach the top of HFP in beginner logic.
+  - Volcano honeycomb: if going through icicle grotto from the bottom, requires talon trot. Added missing tall jump requirement for beginner logic.
+  - Icy side Pillar Cheato page: added talon trot requirement if going through icicle grotto as BK, in advanced and glitched logic.
+  - Sack Race Note: reworked logic.
+  - Central Cavern jinjo: can be gotten with the bee.
+  - Pot of Gold honeycomb: can be gotten with the bee.
+
 # 3.1.2-beta
  - Fix Blue Eggs getting removed permanently
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# 3.1.3-beta
+# 3.3-beta
  - Logic fixes:
   - Atlantis access: fixed dumb mistake that required egg aim or third person egg shooting to reach atlantis, in beginner and normal logic.
   - JRL Pipe Honeycomb: if using leg spring, wing whack is no longer required. Advanced and glitched logic can shoot a clockwork to the honeycomb.
@@ -10,6 +10,12 @@
   - Sack Race Note: reworked logic.
   - Central Cavern jinjo: can be gotten with the bee.
   - Pot of Gold honeycomb: can be gotten with the bee.
+ - Framework Core modification
+  - 2 RAM addresses are checked on every frame due to Chuffy.
+  - This Fixes Train Station giving free Checks and game stopped sending Checks.
+ - More Gruntilda Insults on Deathlink
+ - Custom Jiggy amounts, Minimium for all worlds to open is 1 Jiggy.
+ - Minor change with Roysten Flags
 
 # 3.1.2-beta
  - Fix Blue Eggs getting removed permanently

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -6783,8 +6783,10 @@ function set_checked_STATIONS() --Only run transitioning maps
         else
             if CURRENT_MAP == 0x155 or CURRENT_MAP == 0xD7 or CURRENT_MAP == 0x12A or CURRENT_MAP == 0xEC
             or CURRENT_MAP == 0x114 or CURRENT_MAP == 0x102 or CURRENT_MAP == 0x129 or CURRENT_MAP == 0xD0
+            or CURRENT_MAP == 0x127 or CURRENT_MAP == 0x128 or CURRENT_MAP == 0x100 or CURRENT_MAP == 0x112
             or NEXT_MAP == 0x155 or NEXT_MAP == 0xD7 or NEXT_MAP == 0x12A or NEXT_MAP == 0xEC
             or NEXT_MAP == 0x114 or NEXT_MAP == 0x102 or NEXT_MAP == 0x129 or NEXT_MAP == 0xD0
+            or NEXT_MAP == 0x100 or NEXT_MAP == 0x112
             then
                 for locationId, get_addr in pairs(ADDRESS_MAP['STATIONS'])
                 do
@@ -6804,7 +6806,7 @@ function set_checked_STATIONS() --Only run transitioning maps
 end
 
 function set_AP_STATIONS() -- Only run after Transition
-    if mainmemory.readbyte(0x11B065) ~= 4 -- Not During Cutscene
+    if mainmemory.readbyte(0x11B065) ~= 4
     then
         for stationId, value in pairs(AGI_STATIONS)
         do
@@ -6832,11 +6834,12 @@ end
 function check_STATION_BUTTONS()
     if ASSET_MAP_CHECK[CURRENT_MAP] ~= nil
     then
-        -- Hard code ALL Stations to Not set the AGI UNTIL close to sign 
         if CURRENT_MAP == 0x155 or CURRENT_MAP == 0xD7 or CURRENT_MAP == 0x12A or CURRENT_MAP == 0xEC
-            or CURRENT_MAP == 0x114 or CURRENT_MAP == 0x102 or CURRENT_MAP == 0x129
+            or CURRENT_MAP == 0x114 or CURRENT_MAP == 0x102 or CURRENT_MAP == 0x129 or CURRENT_MAP == 0x127
+            or CURRENT_MAP == 0x128 or CURRENT_MAP == 0x100 or CURRENT_MAP == 0x112
             or NEXT_MAP == 0x155 or NEXT_MAP == 0xD7 or NEXT_MAP == 0x12A or NEXT_MAP == 0xEC
-            or NEXT_MAP == 0x114 or NEXT_MAP == 0x102 or NEXT_MAP == 0x129
+            or NEXT_MAP == 0x114 or NEXT_MAP == 0x102 or NEXT_MAP == 0x129 or NEXT_MAP == 0x127
+            or NEXT_MAP == 0x128 or NEXT_MAP == 0x100 or NEXT_MAP == 0x112
         then
             STATION_BTN_TIMER = STATION_BTN_TIMER + 1
             -- if STATION_BTN_TIMER == 25
@@ -8203,7 +8206,7 @@ function DPadStats()
         then
             CHECK_MOVES_L = false
         end
-		-- Check Collected Treble and Victory Condition
+		-- Check Collected Treble, Stations and Victory Condition
 		if check_controls ~= nil and check_controls['P1 DPad D'] == true and check_controls['P1 L'] == false and CHECK_MOVES_D == false
         then
             print(" ")
@@ -8217,12 +8220,23 @@ function DPadStats()
                 end
             end
 			print(" ")
-			print("Opened Train Stations:")
-            for locationId, values in pairs(ADDRESS_MAP["STATIONS"])
-            do        
-                local results = BTRAMOBJ:checkFlag(values['addr'], values['bit'])
-                if results == true then
-                    print(values['name'])
+            if DEBUG_STATION == true
+            then
+                print("DEBUGGING Opened Train Stations:")
+                for locationId, values in pairs(ADDRESS_MAP["STATIONS"])
+                do        
+                    local results = BTRAMOBJ:checkFlag(values['addr'], values['bit'])
+                    if results == true then
+                        print(values['name'])
+                    end
+                end
+            end
+            print("Open Train Stations:")
+            for apId, itemId in pairs(receive_map)
+            do 
+                if ADDRESS_MAP["STATIONS"][itemId] ~= nil
+                then 
+                    print(ADDRESS_MAP["STATIONS"][itemId]['name'])
                 end
             end
             if GOAL_TYPE ~= 0
@@ -8337,7 +8351,7 @@ function DPadStats()
                 BTRAMOBJ:setFlag(0xA1, 7, "Automatic Energy Regain")
                 REGEN = true
                 print(" ")
-                print("Automatic Energy Regain Enabled")
+                print("Energy Regen Enabled")
                 REGEN_HOLD = true
             end
         elseif check_controls ~= nil and check_controls['P1 DPad D'] == true and check_controls['P1 L'] == true and REGEN == true and REGEN_HOLD == false
@@ -8346,9 +8360,9 @@ function DPadStats()
             BTRAMOBJ:clearFlag(0xA1, 7)
             REGEN = false
             print(" ")
-            print("Automatic Energy Regain Disabled")
+            print("Energy Regen Disabled")
             REGEN_HOLD = true
-        elseif check_controls ~= nil and (check_controls['P1 DPad D'] == true and check_controls['P1 L'] == true) and REGEN_HOLD == true
+        elseif check_controls ~= nil and (check_controls['P1 DPad D'] == false or check_controls['P1 L'] == false) and REGEN_HOLD == true
         then 
             REGEN_HOLD = false
         end

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -2937,8 +2937,8 @@ local ADDRESS_MAP = {
     },
     ['ROYSTEN'] = {
         ["1230777"] = {
-            ['addr'] = 0x36,
-            ['bit'] = 2,
+            ['addr'] = 0x9E,
+            ['bit'] = 6,
             ['name'] = "SM: Roysten Reward 1"
         },
         ["1230778"] = {
@@ -5481,7 +5481,7 @@ end
 function check_freed_roysten() -- Roysten asset loads then deloads if abilities are set.
     if (CURRENT_MAP == 0xAF or NEXT_MAP == 0xAF) and (ROYSTEN["1230778"] == false or ROYSTEN["1230777"] == false)
     then
-        if ROYSTEN_TIMER <= 30 then -- Enough time for deloading Roysten to pass
+        if ROYSTEN_TIMER <= 40 then -- Enough time for deloading Roysten to pass
             if DEBUG_ROYSTEN == true
             then
                 print("Roysten timer")
@@ -8232,11 +8232,16 @@ function DPadStats()
                 end
             end
             print("Open Train Stations:")
+            local TRAIN_TBL = {}
             for apId, itemId in pairs(receive_map)
-            do 
+            do
                 if ADDRESS_MAP["STATIONS"][itemId] ~= nil
-                then 
-                    print(ADDRESS_MAP["STATIONS"][itemId]['name'])
+                then
+                    if TRAIN_TBL[itemId] == nil
+                    then
+                        print(ADDRESS_MAP["STATIONS"][itemId]['name'])
+                        TRAIN_TBL[itemId] = "Y"
+                    end
                 end
             end
             if GOAL_TYPE ~= 0

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -15,7 +15,7 @@ local math = require('math')
 require('common')
 
 local SCRIPT_VERSION = 4
-local BT_VERSION = "V3.1.2"
+local BT_VERSION = "V3.2"
 local PLAYER = ""
 local SEED = 0
 

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -57,7 +57,7 @@ bt_loc_name_to_id = network_data_package["games"]["Banjo-Tooie"]["location_name_
 bt_itm_name_to_id = network_data_package["games"]["Banjo-Tooie"]["item_name_to_id"]
 
 script_version: int = 4
-version: str = "V3.1.2"
+version: str = "V3.2"
 
 def get_item_value(ap_id):
     return ap_id

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -10,6 +10,7 @@ from typing import Union
 import zipfile
 from asyncio import StreamReader, StreamWriter
 
+
 # CommonClient import first to trigger ModuleUpdater
 from CommonClient import CommonContext, server_loop, gui_enabled, \
     ClientCommandProcessor, logger, get_base_parser
@@ -123,6 +124,7 @@ class BanjoTooieContext(CommonContext):
         self.sendSlot = False
         self.sync_ready = False
         self.startup = False
+        # AquaPhoenix Contributed with the Gruntilda Insults
         self.death_messages = [
             "Gruntilda:    Did you hear that lovely clack, \n                     My broomstick gave you such a whack!",
             "Gruntilda:    AAAH! I see it makes you sad, \n                     To know your skills are really bad!",
@@ -131,7 +133,13 @@ class BanjoTooieContext(CommonContext):
             "Gruntilda:    Hopeless bear runs to and fro, \n                     But takes a whack for being so slow!",
             "Gruntilda:    So I got you there once more, \n                     I knew your skills were very poor!",
             "Gruntilda:    Simply put I'm rather proud, \n                     Your yelps and screams I heard quite loud!",
-            "Gruntilda:    Grunty's fireball you did kiss, \n                     You're so slow I can hardly miss!"
+            "Gruntilda:    Grunty's fireball you did kiss, \n                     You're so slow I can hardly miss!",
+            "Gruntilda:    In this world you breathe your last,\n                     Now your friends had better think fast!",
+            "Gruntilda:    This is fun it's quite a treat, \n                     To see you suffer in defeat",
+            "Gruntilda:    That death just now, I saw coming, \n                Your skill issues are rather stunning!",
+            "Gruntilda:    Seeing this pathetic display, \n                Is serotonin in my day",
+            "Gruntilda:    What a selfish thing to do,\n                Your friends just died because of you!",
+            "Gruntilda:    You tried something rather stupid,\n                I hope no one will try what you did"
         ]
 
     async def server_auth(self, password_requested: bool = False):

--- a/worlds/banjo_tooie/Options.py
+++ b/worlds/banjo_tooie/Options.py
@@ -210,62 +210,62 @@ class World1(Range):
     """If you picked custom, what is the jiggy requirement for World 1?"""
     display_name = "World 1 Jiggy requirement"
     range_start = 1
-    range_end = 3
+    range_end = 1
     default = 1
 
 class World2(Range):
     """If you picked custom, what is the jiggy requirement for World 2?"""
     display_name = "World 2 Jiggy requirement"
-    range_start = 2
+    range_start = 1
     range_end = 20
     default = 4
 
 class World3(Range):
     """If you picked custom, what is the jiggy requirement for World 3?"""
     display_name = "World 3 Jiggy requirement"
-    range_start = 3
+    range_start = 1
     range_end = 30
     default = 8
 
 class World4(Range):
     """If you picked custom, what is the jiggy requirement for World 4?"""
     display_name = "World 4 Jiggy requirement"
-    range_start = 4
+    range_start = 1
     range_end = 40
     default = 14
 
 class World5(Range):
     """If you picked custom, what is the jiggy requirement for World 5?"""
     display_name = "World 5 Jiggy requirement"
-    range_start = 5
+    range_start = 1
     range_end = 50
     default = 20
 
 class World6(Range):
     """If you picked custom, what is the jiggy requirement for World 6?"""
     display_name = "World 6 Jiggy requirement"
-    range_start = 6
+    range_start = 1
     range_end = 60
     default = 28
 
 class World7(Range):
     """If you picked custom, what is the jiggy requirement for World 7?"""
     display_name = "World 7 Jiggy requirement"
-    range_start = 7
+    range_start = 1
     range_end = 70
     default = 36
 
 class World8(Range):
     """If you picked custom, what is the jiggy requirement for World 8?"""
     display_name = "World 8 Jiggy requirement"
-    range_start = 8
+    range_start = 1
     range_end = 90
     default = 45
 
 class World9(Range):
     """If you picked custom, what is the jiggy requirement for Cauldon Keep?"""
     display_name = "Cauldon Keep Jiggy requirement"
-    range_start = 9
+    range_start = 1
     range_end = 90
     default = 55
 

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -424,7 +424,7 @@ class BanjoTooieRules:
             locationName.GLOWBOTL1: lambda state: self.glowbo_tdl(state),
             locationName.GLOWBOTL2: lambda state: self.glowbo_tdl(state),
 
-            locationName.GLOWBOHP2: lambda state: self.lower_icy_side(state),
+            locationName.GLOWBOHP2: lambda state: self.hfp_top(state),
 
             locationName.GLOWBOCC1: lambda state: self.ccl_glowbo_pool(state),
             locationName.GLOWBOCC2: lambda state: self.glowbo_cavern(state),
@@ -1561,28 +1561,28 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = self.check_mumbo_magic(state, itemName.MUMBOHP) and self.fire_eggs(state) and \
-                    self.taxi_pack(state) and self.tall_jump(state) and self.lower_icy_side(state)
+                    self.taxi_pack(state) and self.tall_jump(state) and self.hfp_top(state)
         elif self.world.options.logic_type == 1: # normal
             logic = self.check_mumbo_magic(state, itemName.MUMBOHP) and self.has_fire(state) and \
-                    self.taxi_pack(state) and self.tall_jump(state) and self.lower_icy_side(state)
+                    self.taxi_pack(state) and self.tall_jump(state) and self.hfp_top(state)
         elif self.world.options.logic_type == 2: # advanced
             logic = self.check_mumbo_magic(state, itemName.MUMBOHP) and self.has_fire(state) and \
-                    self.taxi_pack(state) and self.tall_jump(state) and self.lower_icy_side(state)
+                    self.taxi_pack(state) and self.tall_jump(state) and self.hfp_top(state)
         elif self.world.options.logic_type == 3: # glitched
             logic = self.check_mumbo_magic(state, itemName.MUMBOHP) and self.has_fire(state) and \
-                    self.taxi_pack(state) and self.tall_jump(state) and self.lower_icy_side(state)
+                    self.taxi_pack(state) and self.tall_jump(state) and self.hfp_top(state)
         return logic
 
     def jiggy_boggy(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.lower_icy_side(state) and self.shack_pack(state) and self.small_elevation(state)
+            logic = self.hfp_top(state) and self.shack_pack(state) and self.small_elevation(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.lower_icy_side(state) and self.shack_pack(state) and self.small_elevation(state)
+            logic = self.hfp_top(state) and self.shack_pack(state) and self.small_elevation(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.lower_icy_side(state) and self.shack_pack(state) and self.small_elevation(state)
+            logic = self.hfp_top(state) and self.shack_pack(state) and self.small_elevation(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.lower_icy_side(state) and (self.shack_pack(state) or (self.clockwork_eggs(state) and self.third_person_egg_shooting(state) and (self.talon_trot(state) or self.flap_flip(state))) or self.leg_spring(state))
+            logic = self.hfp_top(state) and (self.shack_pack(state) or (self.clockwork_eggs(state) and self.third_person_egg_shooting(state) and (self.talon_trot(state) or self.flap_flip(state))) or self.leg_spring(state))
         return logic
     
     def jiggy_ice_station(self, state: CollectionState) -> bool:
@@ -1939,22 +1939,20 @@ class BanjoTooieRules:
                     self.grip_grab(state) and self.spring_pad(state) and self.talon_trot(state)
         elif self.world.options.logic_type == 1: # normal
             logic = ((self.has_explosives(state) or self.bill_drill(state))\
-                    and self.grip_grab(state) and self.spring_pad(state) and self.talon_trot(state))\
+                        and self.grip_grab(state) and self.spring_pad(state) and self.talon_trot(state))\
                     or (self.has_explosives(state) and self.spring_pad(state)\
-                    and (self.glide(state) or (self.leg_spring(state) and \
-                    self.wing_whack(state))))
+                        and (self.glide(state) or self.leg_spring(state)))
         elif self.world.options.logic_type == 2: # advanced
             logic = ((self.has_explosives(state) or self.bill_drill(state))\
-                    and self.grip_grab(state) and self.spring_pad(state) and self.talon_trot(state))\
+                        and self.grip_grab(state) and self.spring_pad(state) and self.talon_trot(state))\
                     or (self.has_explosives(state) and self.spring_pad(state)\
-                    and (self.glide(state) or (self.leg_spring(state) and \
-                    self.wing_whack(state))))
+                        and (self.glide(state) or self.leg_spring(state)))\
+                    or self.veryLongJump(state) and self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
             logic = ((self.has_explosives(state) or self.bill_drill(state))\
-                    and self.grip_grab(state) and self.spring_pad(state) and self.talon_trot(state))\
+                        and self.grip_grab(state) and self.spring_pad(state) and self.talon_trot(state))\
                     or (self.has_explosives(state) and self.spring_pad(state)\
-                    and (self.glide(state) or (self.leg_spring(state) and \
-                    self.wing_whack(state))))
+                        and (self.glide(state) or self.leg_spring(state)))
         return logic
     
     def honeycomb_lakeside(self, state: CollectionState) -> bool:
@@ -2032,21 +2030,21 @@ class BanjoTooieRules:
     def honeycomb_volcano(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = (self.split_up(state) and (self.tall_jump(state) and (self.wing_whack(state) or self.glide(state)) or self.leg_spring(state)))\
-                    or (self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state))
+            logic = self.split_up(state) and (self.tall_jump(state) and (self.wing_whack(state) or self.glide(state)) or self.leg_spring(state))\
+                    or self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state) and self.talon_trot(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = (self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
-                    or (self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state))
+            logic = self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state))\
+                    or self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state) and self.talon_trot(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = (self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
-                    or (self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state))\
+            logic = self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state))\
+                    or self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state) and self.talon_trot(state)\
                     or self.extremelyLongJump(state)\
-                    or (self.hfp_top(state) and self.clockwork_shot(state))
+                    or self.hfp_top(state) and self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
-                    or (self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state))\
+            logic = self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state))\
+                    or self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state) and self.talon_trot(state)\
                     or self.extremelyLongJump(state) \
-                    or (self.hfp_top(state) and self.clockwork_shot(state))
+                    or self.hfp_top(state) and self.clockwork_shot(state)
         return logic
     
     def honeycomb_hfp_station(self, state: CollectionState) -> bool:
@@ -2107,13 +2105,13 @@ class BanjoTooieRules:
     def honeycomb_pot(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.flight_pad(state)
+            logic = self.flight_pad(state) or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 1: # normal
-            logic = (self.flight_pad(state) or self.wing_whack(state) or self.glide(state))
+            logic = (self.flight_pad(state) or self.wing_whack(state) or self.glide(state)) or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 2: # advanced
-            logic = (self.flight_pad(state) or self.wing_whack(state) or self.glide(state))
+            logic = (self.flight_pad(state) or self.wing_whack(state) or self.glide(state)) or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.flight_pad(state) or self.wing_whack(state) or self.glide(state))
+            logic = (self.flight_pad(state) or self.wing_whack(state) or self.glide(state)) or state.has(itemName.HUMBACC, self.player)
         return logic
     
     def plateau_top(self, state: CollectionState) -> bool:
@@ -2423,7 +2421,7 @@ class BanjoTooieRules:
             logic = self.hfp_top(state) and\
                     (self.climb(state) and self.shack_pack(state)\
                     or ((self.leg_spring(state) or self.climb(state)) and self.clockwork_eggs(state)))\
-                    or ((self.talon_trot(state) or self.split_up(state)) and self.clockwork_eggs(state) and self.egg_aim(state))
+                    or ((self.talon_trot(state) or self.split_up(state)) and self.clockwork_shot(state))
         return logic
     
     def cheato_icy_pillar(self, state: CollectionState) -> bool:
@@ -2437,11 +2435,11 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 2: # advanced
             logic = ((self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state))))\
                     or self.leg_spring(state)\
-                    or (self.grenade_eggs(state) and self.clockwork_shot(state) and self.small_elevation(state) and self.spring_pad(state))
+                    or (self.grenade_eggs(state) and self.clockwork_shot(state) and self.small_elevation(state) and self.spring_pad(state) and self.talon_trot(state))
         elif self.world.options.logic_type == 3: # glitched
             logic = ((self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state))))\
                     or self.leg_spring(state)\
-                    or (self.grenade_eggs(state) and self.clockwork_shot(state) and self.small_elevation(state) and self.spring_pad(state))
+                    or (self.grenade_eggs(state) and self.clockwork_shot(state) and self.small_elevation(state) and self.spring_pad(state) and self.talon_trot(state))
         return logic
     
     def cheato_potgold(self, state: CollectionState) -> bool:
@@ -3037,7 +3035,7 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = self.glide(state) and self.grenade_eggs(state) and \
-                    self.egg_aim(state)
+                    self.egg_aim(state) and self.tall_jump(state)
         elif self.world.options.logic_type == 1: # normal
             logic = self.glide(state) or (self.leg_spring(state) and 
                     self.wing_whack(state))
@@ -3052,21 +3050,21 @@ class BanjoTooieRules:
     def jinjo_mildred(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.lower_icy_side(state) and self.fire_eggs(state) or self.has_explosives(state) or \
+            logic = self.hfp_top(state) and self.fire_eggs(state) or self.has_explosives(state) or \
                     self.bill_drill(state) 
         elif self.world.options.logic_type == 1: # normal
-            logic = self.lower_icy_side(state) and (
+            logic = self.hfp_top(state) and (
                 (self.small_elevation(state) or self.beak_buster(state)) and (self.fire_eggs(state) or self.has_explosives(state) or self.bill_drill(state))\
                 or (self.check_mumbo_magic(state, itemName.MUMBOHP) and self.tall_jump(state))\
                 or self.split_up(state) and (self.tall_jump(state) and  self.leg_spring(state)) and (self.fire_eggs(state) or self.has_explosives(state)))
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.lower_icy_side(state) and (
+            logic = self.hfp_top(state) and (
                 (self.small_elevation(state) or self.beak_buster(state)) and (self.fire_eggs(state) or self.has_explosives(state) or self.bill_drill(state))\
                 or (self.check_mumbo_magic(state, itemName.MUMBOHP) and self.tall_jump(state))\
                 or self.split_up(state) and (self.tall_jump(state) and  self.leg_spring(state)) and (self.fire_eggs(state) or self.has_explosives(state))\
                 or self.clockwork_shot(state))
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.lower_icy_side(state) and (
+            logic = self.hfp_top(state) and (
                 (self.small_elevation(state) or self.beak_buster(state)) and (self.fire_eggs(state) or self.has_explosives(state) or self.bill_drill(state))\
                 or (self.check_mumbo_magic(state, itemName.MUMBOHP) and self.tall_jump(state))\
                 or self.split_up(state) and (self.tall_jump(state) and  self.leg_spring(state)) and (self.fire_eggs(state) or self.has_explosives(state))\
@@ -3111,22 +3109,26 @@ class BanjoTooieRules:
     def jinjo_central(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.split_up(state) and self.spring_pad(state)
+            logic = self.split_up(state) and self.spring_pad(state)\
+                    or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 1: # normal
             logic = self.split_up(state) and self.spring_pad(state)\
                     or self.springy_step_shoes(state) and (self.bill_drill(state) or self.flutter(state) or self.air_rat_a_tat_rap(state) or self.split_up(state))\
-                    or self.leg_spring(state)
+                    or self.leg_spring(state)\
+                    or state.has(itemName.HUMBACC, self.player)
                      
         elif self.world.options.logic_type == 2: # advanced
             logic = self.split_up(state) and self.spring_pad(state)\
                     or self.clockwork_shot(state)\
                     or self.springy_step_shoes(state) and (self.bill_drill(state) or self.flutter(state) or self.air_rat_a_tat_rap(state) or self.split_up(state))\
-                    or self.leg_spring(state)
+                    or self.leg_spring(state)\
+                    or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 3: # glitched
             logic = self.split_up(state) and self.spring_pad(state)\
                     or self.clockwork_shot(state)\
                     or self.springy_step_shoes(state) and (self.bill_drill(state) or self.flutter(state) or self.air_rat_a_tat_rap(state) or self.split_up(state))\
-                    or self.leg_spring(state)
+                    or self.leg_spring(state)\
+                    or state.has(itemName.HUMBACC, self.player)
         return logic
 
     def jinjo_humba_ccl(self, state: CollectionState) -> bool:
@@ -3717,13 +3719,24 @@ class BanjoTooieRules:
     def notes_sack_race(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.notes_ccl_high(state)
+            logic = self.flight_pad(state)\
+                    or self.long_jump(state) and self.climb(state)\
+                    or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.notes_ccl_low(state)
+            logic = self.flight_pad(state)\
+                    or self.climb(state) and (self.long_jump(state) or self.grip_grab(state) or self.pack_whack(state) or self.sack_pack(state))\
+                    or self.leg_spring(state) and (self.glide(state) or self.wing_whack(state))\
+                    or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.notes_ccl_low(state)
+            logic = self.flight_pad(state)\
+                    or self.climb(state) and (self.long_jump(state) or self.grip_grab(state) or self.pack_whack(state) or self.sack_pack(state))\
+                    or self.leg_spring(state) and (self.glide(state) or self.wing_whack(state))\
+                    or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.notes_ccl_low(state)
+            logic = self.flight_pad(state)\
+                    or self.climb(state) and (self.long_jump(state) or self.grip_grab(state) or self.pack_whack(state) or self.sack_pack(state))\
+                    or self.leg_spring(state) and (self.glide(state) or self.wing_whack(state))\
+                    or state.has(itemName.HUMBACC, self.player)
         return logic
     
     def ccl_glowbo_pool(self, state: CollectionState) -> bool:
@@ -3868,9 +3881,9 @@ class BanjoTooieRules:
 
     def can_reach_atlantis(self, state: CollectionState) -> bool:
         if self.world.options.logic_type == 0: # beginner
-            return self.ice_eggs(state) and self.long_swim(state) and self.sub_aqua_egg_aiming(state)
+            return state.has(itemName.IEGGS, self.player) and self.long_swim(state) and self.sub_aqua_egg_aiming(state)
         elif self.world.options.logic_type == 1: # normal
-            return self.ice_eggs(state) and self.long_swim(state) and self.sub_aqua_egg_aiming(state)
+            return state.has(itemName.IEGGS, self.player) and self.long_swim(state) and self.sub_aqua_egg_aiming(state)
         elif self.world.options.logic_type == 2: # advanced
             return self.long_swim(state)
         elif self.world.options.logic_type == 3: # glitched
@@ -4128,8 +4141,8 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 2: # advanced
             logic = self.HFP_hot_water_cooled(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.HFP_hot_water_cooled(state) or \
-                (self.grip_grab(state) and self.flutter(state) and self.ground_rat_a_tat_rap(state) and self.tall_jump(state))
+            logic = self.HFP_hot_water_cooled(state)\
+                or (self.grip_grab(state) and self.flutter(state) and self.ground_rat_a_tat_rap(state) and self.tall_jump(state))
         return logic
 
     def WorldUnlocks_req(self, state: CollectionState, locationId: int) -> bool: #1
@@ -4659,7 +4672,7 @@ class BanjoTooieRules:
                state.can_reach_region(regionName.CC, self.player) and \
                self.split_up(state) and\
                self.ground_attack(state) and\
-               self.dive(state)
+               (self.dive(state) or self.shack_pack(state))
 
     def can_use_floatus(self, state) -> bool:
         return self.taxi_pack(state) and self.hatch(state)
@@ -5044,7 +5057,7 @@ class BanjoTooieRules:
         return logic
     
     def humbaHFP(self, state: CollectionState) -> bool:
-        return self.lower_icy_side(state) and state.has(itemName.HUMBAHP, self.player)
+        return self.hfp_top(state) and state.has(itemName.HUMBAHP, self.player)
     
     def mumboCCL(self, state: CollectionState) -> bool:
         return self.tall_jump(state) and state.has(itemName.MUMBOCC, self.player)
@@ -5127,46 +5140,38 @@ class BanjoTooieRules:
     def hfp_top(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.small_elevation(state) or self.split_up(state) or self.flight_pad(state) or\
-                    (state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.TRAINSWHP1, self.player))
+            logic = self.small_elevation(state)\
+                    or self.flight_pad(state)\
+                    or (state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.TRAINSWHP1, self.player))\
+                    or self.has_explosives(state)
         elif self.world.options.logic_type == 1: # normal
             logic = self.small_elevation(state)\
                     or self.flight_pad(state)\
                     or state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.TRAINSWHP1, self.player)\
-                    or (self.has_explosives(state) or state.has(itemName.MUMBOHP, self.player)) and state.has(itemName.HUMBAHP, self.player) # Do not replace with humbaHFP(), it causes an infinite loop.
-                    
+                    or self.has_explosives(state)\
+                    or state.has(itemName.MUMBOHP, self.player)
         elif self.world.options.logic_type == 2: # advanced
             logic = self.small_elevation(state)\
-                    or self.split_up(state)\
                     or self.flight_pad(state)\
+                    or self.split_up(state)\
                     or state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.TRAINSWHP1, self.player)\
-                    or (self.has_explosives(state) or state.has(itemName.MUMBOHP, self.player)) and state.has(itemName.HUMBAHP, self.player) # Do not replace with humbaHFP(), it causes an infinite loop.
+                    or self.has_explosives(state)\
+                    or state.has(itemName.MUMBOHP, self.player)
         elif self.world.options.logic_type == 3: # glitched
             logic = self.small_elevation(state)\
-                    or self.split_up(state)\
                     or self.flight_pad(state)\
+                    or self.split_up(state)\
                     or state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.TRAINSWHP1, self.player)\
-                    or (self.has_explosives(state) or state.has(itemName.MUMBOHP, self.player)) and state.has(itemName.HUMBAHP, self.player) # Do not replace with humbaHFP(), it causes an infinite loop.
-        return logic
-
-    def lower_icy_side(self, state: CollectionState) -> bool:
-        logic = True
-        if self.world.options.logic_type == 0: # beginner
-            logic = self.hfp_top(state) or self.has_explosives(state)
-        elif self.world.options.logic_type == 1: # normal
-            logic = self.hfp_top(state) or self.has_explosives(state) or state.has(itemName.MUMBOHP, self.player)
-        elif self.world.options.logic_type == 2: # advanced
-            logic = self.hfp_top(state) or self.has_explosives(state) or state.has(itemName.MUMBOHP, self.player)
-        elif self.world.options.logic_type == 3: # glitched
-            logic = self.hfp_top(state) or self.has_explosives(state) or state.has(itemName.MUMBOHP, self.player)
+                    or self.has_explosives(state)\
+                    or state.has(itemName.MUMBOHP, self.player)
         return logic
     
     def notes_boggy(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.ice_cube_BK(state) and self.lower_icy_side(state) and self.small_elevation(state)
+            logic = self.ice_cube_BK(state) and self.hfp_top(state) and self.small_elevation(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.lower_icy_side(state)\
+            logic = self.hfp_top(state)\
                         and (self.ice_cube_BK(state) and (self.small_elevation(state) or self.beak_buster(state))\
                              or self.split_up(state) and (self.leg_spring(state) or self.tall_jump(state)) and self.ice_cube_kazooie(state)\
                              or self.tall_jump(state) and state.has(itemName.MUMBOHP, self.player)\
@@ -5174,7 +5179,7 @@ class BanjoTooieRules:
                              or self.humbaHFP(state)
                              )
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.lower_icy_side(state)\
+            logic = self.hfp_top(state)\
                         and (self.ice_cube_BK(state) and (self.small_elevation(state) or self.beak_buster(state))\
                              or self.split_up(state) and (self.leg_spring(state) or self.tall_jump(state)) and self.ice_cube_kazooie(state)\
                              or self.tall_jump(state) and state.has(itemName.MUMBOHP, self.player)\
@@ -5183,7 +5188,7 @@ class BanjoTooieRules:
                              or self.humbaHFP(state)
                              )
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.lower_icy_side(state)\
+            logic = self.hfp_top(state)\
                         and (self.ice_cube_BK(state) and (self.small_elevation(state) or self.beak_buster(state))\
                              or self.split_up(state) and (self.leg_spring(state) or self.tall_jump(state)) and self.ice_cube_kazooie(state)\
                              or self.tall_jump(state) and state.has(itemName.MUMBOHP, self.player)\
@@ -5196,9 +5201,9 @@ class BanjoTooieRules:
     def notes_lower_icy_side(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.ice_cube_BK(state) and self.lower_icy_side(state)
+            logic = self.ice_cube_BK(state) and self.hfp_top(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.lower_icy_side(state)\
+            logic = self.hfp_top(state)\
                         and (self.ice_cube_BK(state)\
                              or self.split_up(state) and self.ice_cube_kazooie(state)\
                              or state.has(itemName.MUMBOHP, self.player)\
@@ -5206,7 +5211,7 @@ class BanjoTooieRules:
                              or self.humbaHFP(state)
                              )
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.lower_icy_side(state)\
+            logic = self.hfp_top(state)\
                         and (self.ice_cube_BK(state)\
                              or self.split_up(state) and self.ice_cube_kazooie(state)\
                              or state.has(itemName.MUMBOHP, self.player)\
@@ -5214,7 +5219,7 @@ class BanjoTooieRules:
                              or self.humbaHFP(state)
                              )
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.lower_icy_side(state)\
+            logic = self.hfp_top(state)\
                         and (self.ice_cube_BK(state)\
                              or self.split_up(state) and self.ice_cube_kazooie(state)\
                              or state.has(itemName.MUMBOHP, self.player)\

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -74,7 +74,7 @@ class BanjoTooieWorld(World):
     options: BanjoTooieOptions
 
     def __init__(self, world, player):
-        self.version = "V3.1.2"
+        self.version = "V3.2"
         self.kingjingalingjiggy = False
         self.starting_egg: int = 0
         self.starting_attack: int = 0


### PR DESCRIPTION
# 3.3-beta
 - Logic fixes:
  - Atlantis access: fixed dumb mistake that required egg aim or third person egg shooting to reach atlantis, in beginner and normal logic.
  - JRL Pipe Honeycomb: if using leg spring, wing whack is no longer required. Advanced and glitched logic can shoot a clockwork to the honeycomb.
  - HFP to JRL: Shack Pack can be used to dive in the pool, in HFP.
  - Icicle Grotto Jinjo: needs tall jump for beginner logic.
  - HFP: the access to lower icy side and the top of HFP now use the same logic, since there's the tunnel behind the icy side train switch that was overlooked. Also, split up is no longer an option to reach the top of HFP in beginner logic.
  - Volcano honeycomb: if going through icicle grotto from the bottom, requires talon trot. Added missing tall jump requirement for beginner logic.
  - Icy side Pillar Cheato page: added talon trot requirement if going through icicle grotto as BK, in advanced and glitched logic.
  - Sack Race Note: reworked logic.
  - Central Cavern jinjo: can be gotten with the bee.
  - Pot of Gold honeycomb: can be gotten with the bee.
 - Framework Core modification
  - 2 RAM addresses are checked on every frame due to Chuffy.
  - This Fixes Train Station giving free Checks and game stopped sending Checks.
 - More Gruntilda Insults on Deathlink
 - Custom Jiggy amounts, Minimium for all worlds to open is 1 Jiggy.
 - Minor change with Roysten Flags