### PR TITLE
The epilogue

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Randomize World Entrance loading zones
  - This also includes Caudron Keep's entrance
  - Grunty's Industries and Caudron Keep cannot appear in Mayahem Temple's loading zone. 
+- Deathlink now works under water.
 
 # 3.2-beta
  - Logic fixes:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,12 +1,13 @@
 # 3.3-beta
 - Open Silo Option
- - Choice between opening 0 IoH silos. Note this does not apply if you are randomizing BK moves and Worlds.
- - Open 1 Random Silo. Note that if randomizing BK moves and Worlds, this will go to your first world.
- - Open All Silos.
+ - Choice between:
+   - Opening 0 IoH silos. Note this does not apply if you are randomizing BK moves and Worlds.
+   - Open 1 Random Silo. Note that if randomizing BK moves and Worlds, this will go to your first world.
+   - Open All Silos.
 - Randomize World Entrance loading zones
  - This also includes Caudron Keep's entrance
  - Grunty's Industries and Caudron Keep cannot appear in Mayahem Temple's loading zone. 
-- Deathlink now works under water.
+- Deathlink now works under water and in toxic caves, and kills much faster.
 
 # 3.2-beta
  - Logic fixes:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+# 3.3-beta
+- Open Silo Option
+ - Choice between opening 0 IoH silos. Note this does not apply if you are randomizing BK moves and Worlds.
+ - Open 1 Random Silo. Note that if randomizing BK moves and Worlds, this will go to your first world.
+ - Open All Silos.
+- Randomize World Entrance loading zones
+ - This also includes Caudron Keep's entrance
+ - Grunty's Industries and Caudron Keep cannot appear in Mayahem Temple's loading zone. 
+
 # 3.2-beta
  - Logic fixes:
   - Atlantis access: fixed dumb mistake that required egg aim or third person egg shooting to reach atlantis, in beginner and normal logic.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Archipelago Banjo-Tooie (US-Only) | 3.1.2-Beta
+# Archipelago Banjo-Tooie (US-Only) | 3.3-Beta
 Banjo Tooie for Archipelago 
 
 # Controller Shortcuts with this implementation
@@ -36,26 +36,8 @@ Banjo Tooie for Archipelago
 - Change how Eggs works (YAML Option)
 - Progressive Ability Upgrades
 - T-Rex Roar
-
-# Implemented Banjo-Kazooie Moves in Archipelago
-- Dive
-- Flight Pad
-- Flap Flip
-- Egg Shoot
-- Roll
-- Talon Trot (if set to ALL)
-- Tall Jimp (if set to ALL)
-- Climb
-- Flutter
-- Wonderwing
-- Air Rat-a-tat Rap
-- Beak Buster
-- Turbo Trainers
-- Blue Eggs
-- Ground Rat-a-tat Rap
-- Stilt Stride
-- Beak Barge
-- Beak Bomb
+- Option to open IoH silos
+- Option to open World Entrance Loading Zone
 
 # Possible Win Conditions
 - Beating Hag-1 (Vanilla)
@@ -78,6 +60,7 @@ Go to worlds/banjo_tooie/docs/setup_en.md for detailed instructions how to setup
  - @Cyb3RGER (AP Launcher)
  - @g0goTAS (g0goTBC) - help with logic fixes
  - GDO - Tester
+ - AquaPhoenix - Tester
  - @fhnnhf (coder)
  - @Auztin (HAG-1 Flags and Misc)
 

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -8029,7 +8029,7 @@ function zoneWarp()
             end
         elseif MAP_ENTRANCES[CURRENT_MAP] ~= nil -- Exiting a world
         then
-            if MAP_ENTRANCES[CURRENT_MAP]['exitId'] == zone -- leaving world
+            if MAP_ENTRANCES[CURRENT_MAP]['exitId'] == zone and IOH_MAPS[NEXT_MAP] ~= nil -- leaving world
             then
                 local leaving_level = MAP_ENTRANCES[CURRENT_MAP]['name']
                 local starting_entrance = ""

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -5016,6 +5016,14 @@ local MAP_ENTRANCES = {
         ['exitMap'] = 0x15C
     }
 }
+local IOH_MAPS = {
+    [0x14F] = 'value', -- WH
+    [0x152] = 'value', --  PL
+    [0x154] = 'value', -- PG
+    [0x155] = 'value', -- CT
+    [0x15A] = 'value', -- WL
+    [0x15C] = 'value', -- QM
+}
 
 
 ---------------------------------- JIGGIES ---------------------------------
@@ -7998,8 +8006,9 @@ function zoneWarp()
         local zone = BTRAMOBJ:getEntranceId()
         if MAP_ENTRANCES[NEXT_MAP] ~= nil -- Entering a world
         then
-            if MAP_ENTRANCES[NEXT_MAP]['entranceId'] == zone or -- Entering Main front door
-            (MAP_ENTRANCES[NEXT_MAP]['name'] == "Glitter Gulch Mine" and zone == 16) --GGM fall bug
+            if (MAP_ENTRANCES[NEXT_MAP]['entranceId'] == zone or -- Entering Main front door
+            (MAP_ENTRANCES[NEXT_MAP]['name'] == "Glitter Gulch Mine" and zone == 16)) --GGM fall bug
+            and IOH_MAPS[CURRENT_MAP] ~= nil -- Avoids death warps to wrong level
             then
                 local level_name = MAP_ENTRANCES[NEXT_MAP]['name']
                 local warp_to_name = AP_LOADING_ZONES[level_name]

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -159,7 +159,6 @@ LEVI_PAD_MOVED = false;
 
 local BATH_PADS_QOL = false
 
-
 -------------- GOAL TYPE VARS ------------
 local GOAL_TYPE = nil;
 local MGH_LENGTH = nil;
@@ -183,6 +182,9 @@ local GOGGLES = false;
 
 ---------------- ROAR VARS ---------------
 local ROAR = false;
+
+---------------- IOH SILO VARS -------------
+local OPEN_SILO = "NONE"
 
 -------------- ENCOURAGEMENT MESSAGES ------------
 local ENCOURAGEMENT = {
@@ -5419,32 +5421,60 @@ function collected_JV_TREBLE()
     return true
 end
 
---------------- Randomize Worlds with BK Moves ---------------------------
+--------------- IOH SILO ---------------------------
 
 function init_world_silos()
-    for worlds, tbl in pairs(WORLD_ENTRANCE_MAP)
-    do
-        if tbl["locationId"] == "1230944"
-        then
-            if tbl["defaultName"] == "Glitter Gulch Mine"
-            then
-                BTRAMOBJ:setFlag(0x60, 7)
-            end
-            if tbl["defaultName"] == "Witchyworld"
-            then
-                BTRAMOBJ:setFlag(0x61, 0)
-            end
-            if tbl["defaultName"] == "Cloud Cuckooland" or tbl["defaultName"] == "Terrydactyland"
-            then
-                BTRAMOBJ:setFlag(0x61, 2)
-            end
-            if tbl["defaultName"] == "Jolly Roger's Lagoon" or tbl["defaultName"] == "Hailfire Peaks" or tbl["defaultName"] == "Grunty Industries"
-            then
-                BTRAMOBJ:setFlag(0x61, 1)
-            end
-        end
+    -- for worlds, tbl in pairs(WORLD_ENTRANCE_MAP)
+    -- do
+    --     if tbl["locationId"] == "1230944"
+    --     then
+    --         if tbl["defaultName"] == "Glitter Gulch Mine"
+    --         then
+    --             BTRAMOBJ:setFlag(0x60, 7)
+    --         end
+    --         if tbl["defaultName"] == "Witchyworld"
+    --         then
+    --             BTRAMOBJ:setFlag(0x61, 0)
+    --         end
+    --         if tbl["defaultName"] == "Cloud Cuckooland" or tbl["defaultName"] == "Terrydactyland"
+    --         then
+    --             BTRAMOBJ:setFlag(0x61, 2)
+    --         end
+    --         if tbl["defaultName"] == "Jolly Roger's Lagoon" or tbl["defaultName"] == "Hailfire Peaks" or tbl["defaultName"] == "Grunty Industries"
+    --         then
+    --             BTRAMOBJ:setFlag(0x61, 1)
+    --         end
+    --     end
+    -- end
+    -- archipelago_msg_box("Warp Silo to your first world is now open")
+    if OPEN_SILO == "NONE"
+    then
+        return
+    elseif OPEN_SILO == "ALL"
+    then
+        BTRAMOBJ:setFlag(0x60, 5) -- JV
+        BTRAMOBJ:setFlag(0x60, 6) -- WH
+        BTRAMOBJ:setFlag(0x60, 7) -- PL
+        BTRAMOBJ:setFlag(0x61, 0) -- PG
+        BTRAMOBJ:setFlag(0x61, 1) -- CT
+        BTRAMOBJ:setFlag(0x61, 2) -- WL
+        BTRAMOBJ:setFlag(0x61, 3) -- QM
+    elseif string.find(OPEN_SILO, "Wasteland") ~= nil then
+        BTRAMOBJ:setFlag(0x60, 5)
+        BTRAMOBJ:setFlag(0x61, 2) -- WL
+    elseif string.find(OPEN_SILO, "Quagmire") ~= nil then
+        BTRAMOBJ:setFlag(0x60, 5) -- JV
+        BTRAMOBJ:setFlag(0x61, 3) -- QM
+    elseif string.find(OPEN_SILO, "Plateau") ~= nil then
+        BTRAMOBJ:setFlag(0x60, 5) -- JV
+        BTRAMOBJ:setFlag(0x60, 7) -- PL
+    elseif string.find(OPEN_SILO, "Pine Grove") ~= nil then
+        BTRAMOBJ:setFlag(0x60, 5) -- JV
+        BTRAMOBJ:setFlag(0x61, 0) -- PG
+    elseif string.find(OPEN_SILO, "Cliff Top") ~= nil then
+        BTRAMOBJ:setFlag(0x60, 5) -- JV
+        BTRAMOBJ:setFlag(0x61, 1) -- CT
     end
-    archipelago_msg_box("Warp Silo to your first world is now open")
 end
 
 --------------------------------- Roysten --------------------------------
@@ -8519,9 +8549,7 @@ function initializeFlags()
             BTRAMOBJ:clearFlag(0x1A, 3) -- Stilt Stride
             BTRAMOBJ:clearFlag(0x18, 6) -- Beak Bomb
 
-            if ENABLE_AP_WORLDS == true then -- Randomize Worlds - SILOS!!!
-                init_world_silos()
-            end
+            init_world_silos()
         end
         if ENABLE_AP_CHEATO_REWARDS == true then
             init_CHEATO_REWARDS()
@@ -9374,6 +9402,10 @@ function process_slot(block)
                 end
             end
         end
+    end
+    if block['slot_open_silo'] ~= nil
+    then
+        OPEN_SILO = block['slot_open_silo']
     end
     if block['slot_version'] ~= nil and block['slot_version'] ~= ""
     then

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -7739,6 +7739,9 @@ function killBT()
                 mainmemory.write_u16_be(0x12b062, 0x0100)--max air and suffocation flag?
                 mainmemory.write_u16_be(0x12b068, 0x800C)--max air and suffocation flag?
                 mainmemory.write_u16_be(0x12b06A, 0xF734)--max air and suffocation flag?
+
+                mainmemory.write_u32_be(0x12b050, 0x00)-- kill in water
+                mainmemory.write_u32_be(0x12b054, 0x00)-- kill in water
                 local kill_animation = 0x01 -- funny drowning death
                 if tranformation ~= 0x01
                 then

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -15,7 +15,7 @@ local math = require('math')
 require('common')
 
 local SCRIPT_VERSION = 4
-local BT_VERSION = "V3.2"
+local BT_VERSION = "V3.3"
 local PLAYER = ""
 local SEED = 0
 

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -9554,7 +9554,6 @@ function process_slot(block)
     end
     if block['slot_zones'] ~= nil
     then
-        print(block['slot_zones'])
         AP_LOADING_ZONES = block['slot_zones']
     end
     printGoalInfo();

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -336,7 +336,8 @@ def get_slot_payload(ctx: BanjoTooieContext):
             "slot_token_hunt_length": ctx.slot_data["token_hunt_length"],
             "slot_version": version,
             "slot_text_colour": ctx.slot_data["text_colour"],
-            "slot_open_silo": ctx.slot_data["first_silo"]
+            "slot_open_silo": ctx.slot_data["first_silo"],
+            "slot_zones": ctx.slot_data['loading_zones']
         })
     ctx.sendSlot = False
     return payload

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -57,7 +57,7 @@ bt_loc_name_to_id = network_data_package["games"]["Banjo-Tooie"]["location_name_
 bt_itm_name_to_id = network_data_package["games"]["Banjo-Tooie"]["item_name_to_id"]
 
 script_version: int = 4
-version: str = "V3.2"
+version: str = "V3.3"
 
 def get_item_value(ap_id):
     return ap_id

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -335,7 +335,8 @@ def get_slot_payload(ctx: BanjoTooieContext):
             "slot_jinjo_family_rescue_length": ctx.slot_data["jinjo_family_rescue_length"],
             "slot_token_hunt_length": ctx.slot_data["token_hunt_length"],
             "slot_version": version,
-            "slot_text_colour": ctx.slot_data["text_colour"]
+            "slot_text_colour": ctx.slot_data["text_colour"],
+            "slot_open_silo": ctx.slot_data["first_silo"]
         })
     ctx.sendSlot = False
     return payload

--- a/worlds/banjo_tooie/Names/regionName.py
+++ b/worlds/banjo_tooie/Names/regionName.py
@@ -24,6 +24,17 @@ IOHCTS = "Isle O Hags - Cliff Top Station"
 IOHCT_HFP_ENTRANCE = "Isle O Hags - Cliff Top (Across Bridge)"
 IOHDC  = "Isle O Hags - Another Digger Tunnel"
 
+# These are the loading zones to each level, as seen from OUTSIDE the level. For example, MTE is the loading zone in Wooded Hollow, that normally leads to MT.
+MTE = "Mayahem Temple - Main Entrance"
+GGME = "Glitter Gulch Mine - Main Entrance"
+WWE = "Witchyworld - Main Entrance"
+JRLE = "Jolly Roger's Lagoon - Main Entrance"
+TDLE = "Terrydactyland - Main Entrance"
+GIE = "Grunty's Industries - Main Entrance"
+HFPE = "Grunty's Industries - Main Entrance"
+CCLE = "Cloud Cuckooland - Main Entrance"
+CKE = "Cauldron Keep - Main Entrance"
+
 SMBH = "Spiral Mountain - Banjo's House"
 SMGL = "Spiral Mountain - Grunty's Lair"
 SMBW = "Spiral Mountain - Behind Waterfall"

--- a/worlds/banjo_tooie/Names/regionName.py
+++ b/worlds/banjo_tooie/Names/regionName.py
@@ -31,7 +31,7 @@ WWE = "Witchyworld - Main Entrance"
 JRLE = "Jolly Roger's Lagoon - Main Entrance"
 TDLE = "Terrydactyland - Main Entrance"
 GIE = "Grunty's Industries - Main Entrance"
-HFPE = "Grunty's Industries - Main Entrance"
+HFPE = "Hailfire Peaks - Main Entrance"
 CCLE = "Cloud Cuckooland - Main Entrance"
 CKE = "Cauldron Keep - Main Entrance"
 

--- a/worlds/banjo_tooie/Options.py
+++ b/worlds/banjo_tooie/Options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from Options import Toggle, DeathLink, PerGameCommonOptions, Choice, DefaultOnToggle, Range
+from Options import Toggle, DeathLink, PerGameCommonOptions, Choice, DefaultOnToggle, Range, StartInventoryPool
 
 class EnableMultiWorldMoveList(DefaultOnToggle):
     """Jamjars' Movelist is locked between the MultiWorld. Other players need to unlock Banjo's Moves."""
@@ -292,6 +292,7 @@ class ExceedingItemsFiller(Toggle):
 
 @dataclass
 class BanjoTooieOptions(PerGameCommonOptions):
+    start_inventory_from_pool: StartInventoryPool
     death_link: DeathLink
     activate_overlay_text:ActivateOverlayText
     overlay_text_colour:OverlayTextColour

--- a/worlds/banjo_tooie/Options.py
+++ b/worlds/banjo_tooie/Options.py
@@ -145,7 +145,7 @@ class LogicType(Choice):
 class Silos(Choice):
     """Choose if you want IoH Silos to be closed, randomly open 1 or enable all. If you enabled Randomized Worlds with BK Moves randomized and
        silos set to none, it will be enforced to one."""
-    display_name = "Logic Type"
+    display_name = "Open Silos"
     option_none = 0
     option_one = 1
     option_all = 2

--- a/worlds/banjo_tooie/Options.py
+++ b/worlds/banjo_tooie/Options.py
@@ -117,6 +117,10 @@ class RandomizeWorlds(Toggle):
     """Worlds will open in a randomized order. Randomized Moves and Puzzle Skip Required."""
     display_name = "Randomize Worlds"
 
+class RandomizeWorldZones(Toggle):
+    """World Entrances will warp you to a different world. This does not affect Chuffy."""
+    display_name = "Randomize World Entrances"
+
 class RandomizeStopnSwap(Toggle):
     """Mystery Eggs, their rewards, and the Ice Key are scattered across the MultiWorld."""
     display_name = "Randomize Stop n Swap"
@@ -136,6 +140,15 @@ class LogicType(Choice):
     option_normal = 1
     option_advanced = 2
     option_glitched = 3
+    default = 0
+
+class Silos(Choice):
+    """Choose if you want IoH Silos to be closed, randomly open 1 or enable all. If you enabled Randomized Worlds with BK Moves randomized and
+       silos set to none, it will be enforced to one."""
+    display_name = "Logic Type"
+    option_none = 0
+    option_one = 1
+    option_all = 2
     default = 0
 
 class SpeedUpMinigames(DefaultOnToggle):
@@ -316,6 +329,8 @@ class BanjoTooieOptions(PerGameCommonOptions):
     jinjo_family_rescue_length: JinjoFamilyRescueLength
     token_hunt_length: TokenHuntLength
     randomize_worlds: RandomizeWorlds
+    randomize_world_loading_zone: RandomizeWorldZones
+    open_silos: Silos
     game_length: GameLength
     open_hag1: OpenHag1
     world_1: World1

--- a/worlds/banjo_tooie/Regions.py
+++ b/worlds/banjo_tooie/Regions.py
@@ -797,11 +797,22 @@ def connect_regions(self):
 
     # Silos
     silo = self.single_silo
-    if silo == "NONE":
-        # Do nothing, they're all closed.
-        pass
+    if silo == "NONE" and self.worlds_randomized == True:
+        ioh_lookup = {
+            regionName.MT: regionName.IOHWH,
+            regionName.GM: regionName.IOHPL,
+            regionName.WW: regionName.IOHPG,
+            regionName.JR: regionName.IOHCT,
+            regionName.TL: regionName.IOHWL,
+            regionName.GIO: regionName.IOHQM,
+            regionName.HP: regionName.IOHCT,
+            regionName.CC: regionName.IOHWL,
+            regionName.CK: regionName.IOHWL,
+        }
+        first_silo = ioh_lookup[list(self.randomize_worlds.keys())[0]]
+        region_JV.add_exits({first_silo})
     elif silo == "ALL":
-        region_JV.add_exits({regionName.IOHWH, regionName.IOHPL, regionName.IOHCT, regionName.IOHPG, regionName.IOHWL, regionName.IOHQM})
+        region_JV.add_exits({regionName.IOHPL, regionName.IOHCT, regionName.IOHPG, regionName.IOHWL, regionName.IOHQM})
     else: # The value is a region name of the overworld.
         region_JV.add_exits({silo})
     

--- a/worlds/banjo_tooie/Regions.py
+++ b/worlds/banjo_tooie/Regions.py
@@ -514,7 +514,16 @@ BANJOTOOIEREGIONS: typing.Dict[str, typing.List[str]] = {
     regionName.CK: [],
     regionName.H1: [
         locationName.HAG1
-    ]
+    ],
+    regionName.MTE: [],
+    regionName.GGME: [],
+    regionName.WWE: [],
+    regionName.JRLE: [],
+    regionName.TDLE: [],
+    regionName.GIE: [],
+    regionName.HFPE: [],
+    regionName.CCLE: [],
+    regionName.CKE: [],
 }
     
 def create_regions(self):
@@ -615,8 +624,8 @@ def connect_regions(self):
     region_JV.add_exits({regionName.IOHWH})
 
     region_WH = multiworld.get_region(regionName.IOHWH, player)
-    region_WH.add_exits({regionName.MT, regionName.IOHPL},
-                        {regionName.MT: lambda state: rules.mt_jiggy(state), 
+    region_WH.add_exits({regionName.MTE, regionName.IOHPL},
+                        {regionName.MTE: lambda state: rules.mt_jiggy(state), 
                          regionName.IOHPL: lambda state: rules.WH_to_PL(state)})
 
     region_MT = multiworld.get_region(regionName.MT, player)
@@ -629,21 +638,20 @@ def connect_regions(self):
                         {regionName.TL: lambda state: rules.hatch_to_TDL(state)})
 
     region_PL = multiworld.get_region(regionName.IOHPL, player)
-    region_PL.add_exits({regionName.GM, regionName.IOHPG, regionName.IOHCT},
-                        {regionName.GM: lambda state: rules.PL_to_GGM(state), 
+    region_PL.add_exits({regionName.GGME, regionName.IOHPG, regionName.IOHCT},
+                        {regionName.GGME: lambda state: rules.PL_to_GGM(state), 
                          regionName.IOHPG: lambda state: rules.PL_to_PG(state),
                         regionName.IOHCT: lambda state: rules.split_up(state)})
     
     region_GM = multiworld.get_region(regionName.GM, player)
-    region_GM.add_exits({regionName.GMWSJT, regionName.IOHPL, regionName.CHUFFY, regionName.WW},
+    region_GM.add_exits({regionName.GMWSJT, regionName.CHUFFY, regionName.WW},
     {regionName.GMWSJT: lambda state: rules.can_access_water_storage_jinjo_from_GGM(state),
      regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and rules.ggm_to_chuffy(state),
-     regionName.IOHPL: lambda state: rules.GGM_to_PL(state),
      regionName.WW: lambda state: rules.ggm_to_ww(state)})
     
     region_PG = multiworld.get_region(regionName.IOHPG, player)
-    region_PG.add_exits({regionName.WW, regionName.IOHPGU, regionName.IOHPL},
-    {regionName.WW: lambda state: rules.ww_jiggy(state),
+    region_PG.add_exits({regionName.WWE, regionName.IOHPGU, regionName.IOHPL},
+    {regionName.WWE: lambda state: rules.ww_jiggy(state),
      regionName.IOHPGU: lambda state: rules.dive(state),
      regionName.IOHPL: lambda state: rules.PG_to_PL(state)})
     
@@ -653,14 +661,13 @@ def connect_regions(self):
      regionName.IOHWL: lambda state: state.has(itemName.TTORP, player)})
     
     region_WW = multiworld.get_region(regionName.WW, player)
-    region_WW.add_exits({regionName.IOHPG, regionName.CHUFFY},
-    {regionName.IOHPG: lambda state: rules.ww_jiggy(state),
-     regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and rules.ww_to_chuffy(state)})
+    region_WW.add_exits({regionName.CHUFFY},
+    {regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and rules.ww_to_chuffy(state)})
 
     region_IOHCT = multiworld.get_region(regionName.IOHCT, player)
-    region_IOHCT.add_exits({regionName.IOHCT_HFP_ENTRANCE, regionName.HP, regionName.JR, regionName.CHUFFY, regionName.IOHPL},
-        {regionName.HP:lambda state: rules.hfp_jiggy(state),
-         regionName.JR: lambda state: rules.jrl_jiggy(state),
+    region_IOHCT.add_exits({regionName.IOHCT_HFP_ENTRANCE, regionName.HFPE, regionName.JRLE, regionName.CHUFFY, regionName.IOHPL},
+        {regionName.HFPE:lambda state: rules.hfp_jiggy(state),
+         regionName.JRLE: lambda state: rules.jrl_jiggy(state),
          regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and rules.ioh_to_chuffy(state),
          regionName.IOHPL: lambda state: rules.PG_to_PL(state)})
   
@@ -678,38 +685,35 @@ def connect_regions(self):
                         {regionName.GMWSJT: lambda state: rules.can_access_water_storage_jinjo_from_JRL(state)})
 
     region_HP = multiworld.get_region(regionName.HP, player)
-    region_HP.add_exits({regionName.IOHCT_HFP_ENTRANCE, regionName.MT, regionName.JR, regionName.CHUFFY},
-                        {regionName.IOHCT_HFP_ENTRANCE: lambda state: rules.HFP_to_CTHFP(state),
-                         regionName.MT: lambda state: rules.HFP_to_MT(state),
+    region_HP.add_exits({regionName.MT, regionName.JR, regionName.CHUFFY},
+                        {regionName.MT: lambda state: rules.HFP_to_MT(state),
                          regionName.JR: lambda state: rules.HFP_to_JRL(state),
                          regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and rules.hfp_to_chuffy(state)})
     region_IOHWL = multiworld.get_region(regionName.IOHWL, player)
-    region_IOHWL.add_exits({regionName.IOHPGU, regionName.IOHQM, regionName.TL, regionName.CC},
+    region_IOHWL.add_exits({regionName.IOHPGU, regionName.IOHQM, regionName.TDLE, regionName.CCLE},
                         {regionName.IOHPGU: lambda state: rules.WL_to_PGU(state),
                          regionName.IOHQM: lambda state: rules.springy_step_shoes(state),
-                         regionName.TL: lambda state: rules.tdl_jiggy(state),
-                         regionName.CC: lambda state: rules.ccl_jiggy(state)})
+                         regionName.TDLE: lambda state: rules.tdl_jiggy(state),
+                         regionName.CCLE: lambda state: rules.ccl_jiggy(state)})
     
     region_TL = multiworld.get_region(regionName.TL, player)
     region_TL.add_exits({regionName.TL_HATCH, regionName.WW, regionName.CHUFFY, regionName.IOHWL},
                         {regionName.WW: lambda state: rules.TDL_to_WW(state),
                          regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and rules.tdl_to_chuffy(state),
-                         regionName.IOHWL: lambda state: rules.TDL_to_IOHWL(state),
                          regionName.TL_HATCH: lambda state: rules.long_jump(state),
                          })
     
     region_QM = multiworld.get_region(regionName.IOHQM, player)
-    region_QM.add_exits({regionName.GIO, regionName.IOHWL, regionName.CK},
-                        {regionName.GIO: lambda state: rules.gi_jiggy(state),
+    region_QM.add_exits({regionName.GIE, regionName.IOHWL, regionName.CK},
+                        {regionName.GIE: lambda state: rules.gi_jiggy(state),
                          regionName.IOHWL: lambda state: rules.QM_to_WL(state),
-                         regionName.CK: lambda state: rules.quag_to_CK(state)})
+                         regionName.CKE: lambda state: rules.quag_to_CK(state)})
     
     region_GIO = multiworld.get_region(regionName.GIO, player)
-    region_GIO.add_exits({regionName.GI1, regionName.GI2, regionName.GI3ALL, regionName.IOHQM},
+    region_GIO.add_exits({regionName.GI1, regionName.GI2, regionName.GI3ALL},
                         {regionName.GI1: lambda state: rules.outside_gi_to_floor1(state),
                          regionName.GI2: lambda state: rules.outside_gi_to_floor2(state),
-                         regionName.GI3ALL: lambda state: rules.outside_gi_to_floor3(state),
-                         regionName.IOHQM: lambda state: rules.gi_jiggy(state)})
+                         regionName.GI3ALL: lambda state: rules.outside_gi_to_floor3(state)})
     
     region_GI1 = multiworld.get_region(regionName.GI1, player)
     region_GI1.add_exits({regionName.GIO, regionName.GI2, regionName.GI3ALL, regionName.CHUFFY},
@@ -740,15 +744,64 @@ def connect_regions(self):
                          regionName.GI1: lambda state: state.has(itemName.CHUFFY, self.player) and state.has(itemName.TRAINSWGI, player),
                          regionName.HP: lambda state: state.has(itemName.CHUFFY, self.player) and state.has(itemName.TRAINSWHP1, player)
                          })
-    # Randomize Worlds + BK Moves handling
-    if self.worlds_randomized == True and self.options.randomize_bk_moves.value:
-        first_level = list(self.randomize_worlds.keys())[0]
-        jinjo_village_silo = multiworld.get_region(regionName.IOHJV, player)
-        if first_level == regionName.GM:
-            jinjo_village_silo.add_exits({regionName.IOHPL})
-        if first_level == regionName.WW:
-            jinjo_village_silo.add_exits({regionName.IOHPG})
-        if first_level == regionName.JR or first_level == regionName.HP or first_level == regionName.GIO:
-            jinjo_village_silo.add_exits({regionName.IOHCT})
-        if first_level == regionName.TL or first_level == regionName.CC:
-            jinjo_village_silo.add_exits({regionName.IOHWL})
+    
+    region_mt_entrance = multiworld.get_region(regionName.MTE, player)
+    region_mt_entrance.add_exits({regionName.IOHWH}, {regionName.IOHWH: lambda state: rules.MT_to_WH(state)})
+
+    region_ggm_entrance = multiworld.get_region(regionName.GGME, player)
+    region_ggm_entrance.add_exits({regionName.IOHPL}, {regionName.IOHPL: lambda state: rules.escape_ggm_loading_zone(state)})
+
+    region_ww_entrance = multiworld.get_region(regionName.WWE, player)
+    region_ww_entrance.add_exits({regionName.IOHPG}, {regionName.IOHPG: lambda state: rules.ww_jiggy(state)})
+
+    region_jrl_entrance = multiworld.get_region(regionName.JRLE, player)
+    region_jrl_entrance.add_exits({regionName.IOHCT}, {regionName.IOHCT: lambda state: rules.JRL_to_CT(state)})
+
+    region_tdl_entrance = multiworld.get_region(regionName.TDLE, player)
+    region_tdl_entrance.add_exits({regionName.IOHWL}, {regionName.IOHWL: lambda state: rules.TDL_to_IOHWL(state)})
+
+    region_gi_entrance = multiworld.get_region(regionName.GIE, player)
+    region_gi_entrance.add_exits({regionName.IOHQM}, {regionName.IOHQM: lambda state: rules.gi_jiggy(state)})
+
+    region_hfp_entrance = multiworld.get_region(regionName.HFPE, player)
+    region_hfp_entrance.add_exits({regionName.IOHCT_HFP_ENTRANCE}, {regionName.IOHCT_HFP_ENTRANCE: lambda state: rules.HFP_to_CTHFP(state)})
+
+    # It's not possible to enter CCL other than by the main entrance.
+    # Same thing with CK.
+
+    # World entrance randomisation (and exits)
+    entrance_lookup = {
+            regionName.MT: regionName.MTE,
+            regionName.GM: regionName.GGME,
+            regionName.WW: regionName.WWE,
+            regionName.JR: regionName.JRLE,
+            regionName.TL: regionName.TDLE,
+            regionName.GIO: regionName.GIE,
+            regionName.HP: regionName.HFPE,
+            regionName.CC: regionName.CCLE,
+            regionName.CK: regionName.CKE,
+        }
+    for starting_zone, actual_world in self.loading_zones.items():
+        overworld_entrance = entrance_lookup[starting_zone]
+
+        region_overworld_entrance = multiworld.get_region(overworld_entrance, player)
+        region_overworld_entrance.add_exits({actual_world})
+
+        region_actual_world_entrance = multiworld.get_region(actual_world, player)
+
+        if actual_world == regionName.GM:
+            region_actual_world_entrance.add_exits({overworld_entrance}, {overworld_entrance: lambda state: rules.GGM_to_PL(state)})
+        else:
+            region_actual_world_entrance.add_exits({overworld_entrance})
+            
+
+    # Silos
+    silo = self.single_silo
+    if silo == "NONE":
+        # Do nothing, they're all closed.
+        pass
+    elif silo == "ALL":
+        region_JV.add_exits({regionName.IOHWH, regionName.IOHPL, regionName.IOHCT, regionName.IOHPG, regionName.IOHWL, regionName.IOHQM})
+    else: # The value is a region name of the overworld.
+        region_JV.add_exits({silo})
+    

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -4161,6 +4161,18 @@ class BanjoTooieRules:
         else:
             amt = self.world.randomize_worlds[regionName.MT]
             return state.has(itemName.JIGGY, self.player, amt)
+
+    def MT_to_WH(self, state: CollectionState) -> bool: #1
+        logic = True
+        if self.world.options.logic_type == 0: # beginner
+            logic = self.mt_jiggy(state)
+        elif self.world.options.logic_type == 1: # normal
+            logic = True
+        elif self.world.options.logic_type == 2: # advanced
+            logic = True
+        elif self.world.options.logic_type == 3: # glitched
+            logic = True
+        return logic
     
     def WH_to_PL(self, state: CollectionState) -> bool:
         logic = True
@@ -4184,6 +4196,18 @@ class BanjoTooieRules:
             logic = self.climb(state)
         elif self.world.options.logic_type == 3: # glitched
             logic = self.climb(state)
+        return logic
+
+    def escape_ggm_loading_zone(self, state: CollectionState) -> bool:
+        logic = True
+        if self.world.options.logic_type == 0: # beginner
+            logic = self.gm_jiggy(state) and self.climb(state)
+        elif self.world.options.logic_type == 1: # normal
+            logic = self.climb(state) or self.beak_buster(state) or self.flutter(state) or self.air_rat_a_tat_rap(state)
+        elif self.world.options.logic_type == 2: # advanced
+            logic = self.climb(state) or self.beak_buster(state) or self.flutter(state) or self.air_rat_a_tat_rap(state)
+        elif self.world.options.logic_type == 3: # glitched
+            logic = self.climb(state) or self.beak_buster(state) or self.flutter(state) or self.air_rat_a_tat_rap(state)
         return logic
 
     def PG_to_PL(self, state: CollectionState) -> bool:

--- a/worlds/banjo_tooie/WorldOrder.py
+++ b/worlds/banjo_tooie/WorldOrder.py
@@ -425,17 +425,23 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
                 random.shuffle(worlds)
                 if worlds[0] != regionName.CK and worlds[0] != regionName.GIO:
                     gen_res = True
-            world.loading_zones = {
-                regionName.MT : worlds[0],
-                regionName.GM : worlds[1],
-                regionName.WW : worlds[2],
-                regionName.JR : worlds[3],
-                regionName.TL : worlds[4],
-                regionName.GIO: worlds[5],
-                regionName.HP : worlds[6],
-                regionName.CC : worlds[7],
-                regionName.CK : worlds[8]
-            }
+            if world.worlds_randomized == True:
+                i = 0
+                for location, jiggy in world.randomize_worlds.items():
+                    world.loading_zones[location] = worlds[i]
+                    i = i+1
+            else:
+                world.loading_zones = {
+                    regionName.MT : worlds[0],
+                    regionName.GM : worlds[1],
+                    regionName.WW : worlds[2],
+                    regionName.JR : worlds[3],
+                    regionName.TL : worlds[4],
+                    regionName.GIO: worlds[5],
+                    regionName.HP : worlds[6],
+                    regionName.CC : worlds[7],
+                    regionName.CK : worlds[8]
+                }
         else:
             world.loading_zones = {
                 regionName.MT : regionName.MT,

--- a/worlds/banjo_tooie/WorldOrder.py
+++ b/worlds/banjo_tooie/WorldOrder.py
@@ -22,7 +22,19 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
             world.starting_egg = passthrough['starting_egg']
             world.starting_attack = passthrough['starting_attack']
             world.single_silo = passthrough['first_silo']
+            world.loading_zones = passthrough['loading_zones']
     else:
+        worlds = [
+            regionName.MT,
+            regionName.GM,
+            regionName.WW,
+            regionName.JR,
+            regionName.TL,
+            regionName.GIO,
+            regionName.HP,
+            regionName.CC,
+            regionName.CK
+        ]
         if world.options.randomize_worlds and world.options.randomize_moves == True and \
         world.options.skip_puzzles == True:
             random.shuffle(world.world_sphere_1)
@@ -407,6 +419,35 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
                 random.shuffle(silo_rando)
                 world.single_silo = silo_rando[0]
 
+        if world.options.randomize_world_loading_zone.value == True:
+            gen_res = False
+            while(gen_res == False):
+                random.shuffle(worlds)
+                if worlds[0] != regionName.CK and worlds[0] != regionName.GIO:
+                    gen_res = True
+            world.loading_zones = {
+                regionName.MT : worlds[0],
+                regionName.GM : worlds[1],
+                regionName.WW : worlds[2],
+                regionName.JR : worlds[3],
+                regionName.TL : worlds[4],
+                regionName.GIO: worlds[5],
+                regionName.HP : worlds[6],
+                regionName.CC : worlds[7],
+                regionName.CK : worlds[8]
+            }
+        else:
+            world.loading_zones = {
+                regionName.MT : regionName.MT,
+                regionName.GM : regionName.GM,
+                regionName.WW : regionName.WW,
+                regionName.JR : regionName.JR,
+                regionName.TL : regionName.TL,
+                regionName.GIO: regionName.GIO,
+                regionName.HP : regionName.HP,
+                regionName.CC : regionName.CC,
+                regionName.CK : regionName.CK
+            }
 
 
     

--- a/worlds/banjo_tooie/WorldOrder.py
+++ b/worlds/banjo_tooie/WorldOrder.py
@@ -21,6 +21,7 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
             world.worlds_randomized = bool(passthrough['worlds'] == 'true') 
             world.starting_egg = passthrough['starting_egg']
             world.starting_attack = passthrough['starting_attack']
+            world.single_silo = passthrough['first_silo']
     else:
         if world.options.randomize_worlds and world.options.randomize_moves == True and \
         world.options.skip_puzzles == True:
@@ -248,7 +249,24 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
 
             first_level = list(world.randomize_worlds.keys())[0]
             second_level = list(world.randomize_worlds.keys())[1]
-            if world.options.randomize_bk_moves == 0:
+            #Silos
+            if world.options.open_silos.value == 1:
+                if  first_level == regionName.TL or first_level == regionName.CC:
+                    world.single_silo = regionName.IOHWL
+                if first_level == regionName.GM:
+                    world.single_silo = regionName.IOHPL
+                if  first_level == regionName.WW:
+                    world.single_silo = regionName.IOHPG
+                if first_level == regionName.JR or first_level == regionName.HP:
+                    world.single_silo = regionName.IOHCT
+                if first_level == regionName.GIO:
+                    world.single_silo = regionName.IOHCT
+            elif world.options.open_silos.value == 2:
+                world.single_silo = "ALL"
+            else:
+                world.single_silo = "NONE"
+            #EO Silos
+            if world.options.randomize_bk_moves != 2:
                 if  first_level != regionName.MT and world.options.logic_type != 2:
                     world.multiworld.early_items[world.player][itemName.GGRAB] = 1
                 if  first_level == regionName.WW:
@@ -261,7 +279,22 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
                 if first_level == regionName.GIO:
                     world.multiworld.early_items[world.player][itemName.FEGGS] = 1
                     world.multiworld.early_items[world.player][itemName.TTORP] = 1
-            if world.options.randomize_bk_moves == 2:
+            else: # All BK Moves shuffled
+                #Silos
+                if world.options.open_silos.value != 2:
+                    #if world.options.open_silos.value == 0:
+                        #world.options.open_silos.value = 1 #Override
+                    if  first_level == regionName.TL or first_level == regionName.CC:
+                        world.single_silo = regionName.IOHWL
+                    if first_level == regionName.GM:
+                        world.single_silo = regionName.IOHPL
+                    if  first_level == regionName.WW:
+                        world.single_silo = regionName.IOHPG
+                    if first_level == regionName.JR or first_level == regionName.HP:
+                        world.single_silo = regionName.IOHCT
+                    if first_level == regionName.GIO:
+                        world.single_silo = regionName.IOHCT
+                #EOSilos
                 if  first_level == regionName.WW:
                     world.multiworld.early_items[world.player][itemName.SPLITUP] = 1
                 if first_level == regionName.JR and world.options.randomize_doubloons.value == False \
@@ -357,14 +390,23 @@ def WorldRandomize(world: BanjoTooieWorld) -> None:
                 regionName.CC:  1230951,
                 regionName.CK:  1230952 
             }
-            # order = sorted(world.randomize_worlds.items(), key=lambda x: x[1])
-            # world.randomize_worlds = {}
-            # i = 1
-            # for location, jiggyamt in order:
-            #     world.randomize_worlds.update({location: jiggyamt})
-            #     world.randomize_order.update({i: location})
-            #     i = i + 1
-
             world.worlds_randomized = False
+            #Silos
+            if world.options.open_silos.value == 0:
+                world.single_silo = "NONE"
+            elif world.options.open_silos.value == 2:
+                world.single_silo = "ALL"
+            else:
+                silo_rando = [
+                    regionName.IOHWL,
+                    regionName.IOHPL,
+                    regionName.IOHPG,
+                    regionName.IOHCT,
+                    regionName.IOHQM
+                ]
+                random.shuffle(silo_rando)
+                world.single_silo = silo_rando[0]
+
+
 
     

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -99,6 +99,7 @@ class BanjoTooieWorld(World):
         ]
         self.worlds_randomized = False
         self.single_silo = ""
+        self.loading_zones = {}
         super(BanjoTooieWorld, self).__init__(world, player)
 
     def create_item(self, itemname: str) -> Item:
@@ -628,6 +629,7 @@ class BanjoTooieWorld(World):
         btoptions['starting_egg'] = int(self.starting_egg)
         btoptions['starting_attack'] = int(self.starting_attack)
         btoptions['first_silo'] = self.single_silo
+        btoptions['loading_zones'] = self.loading_zones
         btoptions['silo_option'] = int(self.options.open_silos.value)
         btoptions['version'] = self.version
 

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -98,6 +98,7 @@ class BanjoTooieWorld(World):
         self.world_sphere_2 = [
         ]
         self.worlds_randomized = False
+        self.single_silo = ""
         super(BanjoTooieWorld, self).__init__(world, player)
 
     def create_item(self, itemname: str) -> Item:
@@ -626,6 +627,8 @@ class BanjoTooieWorld(World):
 
         btoptions['starting_egg'] = int(self.starting_egg)
         btoptions['starting_attack'] = int(self.starting_attack)
+        btoptions['first_silo'] = self.single_silo
+        btoptions['silo_option'] = int(self.options.open_silos.value)
         btoptions['version'] = self.version
 
         return btoptions

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -74,7 +74,7 @@ class BanjoTooieWorld(World):
     options: BanjoTooieOptions
 
     def __init__(self, world, player):
-        self.version = "V3.2"
+        self.version = "V3.3"
         self.kingjingalingjiggy = False
         self.starting_egg: int = 0
         self.starting_attack: int = 0

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -554,7 +554,8 @@ class BanjoTooieWorld(World):
             self.multiworld.get_location(locationName.JINJOCC4, self.player).place_locked_item(item)
             self.multiworld.get_location(locationName.JINJOGI3, self.player).place_locked_item(item)
 
-
+    def get_filler_item_name(self) -> str:
+        return itemName.NONE
 
     def banjo_pre_fills(self, itemNameOrGroup: str, locationFindCriteria: str, useGroup: bool ) -> None:
         if useGroup:

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -575,6 +575,26 @@ class BanjoTooieWorld(World):
                     location = self.multiworld.get_location(name, self.player)
                     location.place_locked_item(item)
 
+    @classmethod
+    def stage_write_spoiler(cls, world, spoiler_handle):
+        entrance_hags = {
+            regionName.MT: regionName.IOHWH,
+            regionName.GM: regionName.IOHPL,
+            regionName.WW: regionName.IOHPG,
+            regionName.JR: regionName.IOHCT + " (Jolly Rogers Lagoon Entrance)",
+            regionName.TL: regionName.IOHWL + " (Terrydactyland Entrance)",
+            regionName.GIO: regionName.IOHQM + " (Grunty's Industries Entrance)",
+            regionName.HP: regionName.IOHCT_HFP_ENTRANCE,
+            regionName.CC: regionName.IOHWL + " (Cloud Cuckooland Entrance)",
+            regionName.CK: regionName.IOHQM + " (Caudron Keep Entrance)"
+        }
+        bt_players = world.get_game_players(cls.game)
+        spoiler_handle.write('\n\nBanjo-Tooie Loading Zones:')
+        for player in bt_players:
+            name = world.get_player_name(player)
+            spoiler_handle.write(f"\n\n({name})")
+            for starting_zone, actual_world in world.worlds[player].loading_zones.items():
+                    spoiler_handle.write(f"\n{entrance_hags[starting_zone]} -> {actual_world}")
 
     def fill_slot_data(self) -> Dict[str, Any]:
         btoptions = {}

--- a/yaml-template/template.yaml
+++ b/yaml-template/template.yaml
@@ -79,6 +79,8 @@ Banjo-Tooie:
 
   # Changes which levels are open; Recommended when doing multiworld seeds.
   randomize_worlds: 'false'
+  randomize_world_loading_zone: 'false' # Randomize Entrance Loading Zones
+  
 
   logic_type: 0                # 0: Beginner, 1: Normal, 2: Advanced, 3: glitched
   jingaling_jiggy: 'true'      # True: Always get Jiggy from Jingaling; recommended when playing Multiworld.
@@ -87,6 +89,7 @@ Banjo-Tooie:
   speed_up_minigames: 'true'   # skip to round 3 of kickball, dodgems
   skip_puzzles: 'true'
   skip_klungo: 'true'          # Skips Klungo 1 & 2
+  open_silos: 0                # 0: None, 1: 1 Random Silo, 2: All Silos
 
 
   # Victory Conditions


### PR DESCRIPTION
- Open Silo Option
 - Choice between:
   - Opening 0 IoH silos. Note this does not apply if you are randomizing BK moves and Worlds.
   - Open 1 Random Silo. Note that if randomizing BK moves and Worlds, this will go to your first world.
   - Open All Silos.
- Randomize World Entrance loading zones
 - This also includes Caudron Keep's entrance
 - Grunty's Industries and Caudron Keep cannot appear your first loading zone. 
- Deathlink now works under water and in toxic caves, and kills much faster.
- Implement Inventory Items from Item Pool