### PR TITLE
Pre alpha

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+# 3.3.3-beta
+ - Logic Fixes:
+   - Prison Compound Cheato Page: For beginner logic, you need tall jump to jump from the water to the platforms.
+   - Prison Compound Jiggy: For beginner logic, you need tall jump to jump from the water to the platforms.
+   - MT Pillars Jiggy: For beginner logic, you need tall jump to jump from the water to the platforms, if going through the top of Prison Compound.
+   - GGM Entrance Glowbo: for advanced and glitched logic, can be gotten with a clockwork.
+   - Back-left Fuel Depot Note: for advanced and glitched logic, can be gotten with a clockwork.
+   - Defeating Hag 1: beginner and normal logic get a 2nd type of egg to help with damaging.
+
 # 3.3.2-beta
  - Fix Skivvy Jiggy
  - Fix Open Silos if BK Moves is not randomized.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@
    - MT Pillars Jiggy: For beginner logic, you need tall jump to jump from the water to the platforms, if going through the top of Prison Compound.
    - GGM Entrance Glowbo: for advanced and glitched logic, can be gotten with a clockwork.
    - Back-left Fuel Depot Note: for advanced and glitched logic, can be gotten with a clockwork.
+   - Hot Waterfall Jinjo: removed the damage boost from normal logic.
+   - Sack Race Note: removed Leg Spring + (Wing Whack or glide) from normal logic.
+   - Trash Can Jiggy and Jinjo: Added Leg Spring + Wing Whack as an option to reach the Trash Can, in advanced and glitched logic.
    - Defeating Hag 1: beginner and normal logic get a 2nd type of egg to help with damaging.
 
 # 3.3.2-beta

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # 3.3.2-beta
  - Fix Skivvy Jiggy
  - Fix Open Silos if BK Moves is not randomized.
+ - Fix Canary Mary Cutscene (also made CCL Transitioning Faster)
+ - Fix TDL Train Station softlock
 
 # 3.3.1-beta
  - Logic fixes:

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
    - Sack Race Note: removed Leg Spring + (Wing Whack or glide) from normal logic.
    - Trash Can Jiggy and Jinjo: Added Leg Spring + Wing Whack as an option to reach the Trash Can, in advanced and glitched logic.
    - Defeating Hag 1: beginner and normal logic get a 2nd type of egg to help with damaging.
+  - Logic names are now: Intended / Easy Tricks / Hard Tricks / Glitches
 
 # 3.3.2-beta
  - Fix Skivvy Jiggy

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # 3.3.3-beta
+ - If you choose to have 1 silo open, your first silo will now always lead to the first level (unless Mayahem Temple is your first level. In which case, The silo is randomly selected).
  - Logic Fixes:
    - Prison Compound Cheato Page: For beginner logic, you need tall jump to jump from the water to the platforms.
    - Prison Compound Jiggy: For beginner logic, you need tall jump to jump from the water to the platforms.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
    - MT Pillars Jiggy: For beginner logic, you need tall jump to jump from the water to the platforms, if going through the top of Prison Compound.
    - GGM Entrance Glowbo: for advanced and glitched logic, can be gotten with a clockwork.
    - Back-left Fuel Depot Note: for advanced and glitched logic, can be gotten with a clockwork.
+   - TDL to Wasteland: fixed the broken transition.
    - Hot Waterfall Jinjo: removed the damage boost from normal logic.
    - Sack Race Note: removed Leg Spring + (Wing Whack or glide) from normal logic.
    - Trash Can Jiggy and Jinjo: Added Leg Spring + Wing Whack as an option to reach the Trash Can, in advanced and glitched logic.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Archipelago Banjo-Tooie (US-Only) | 3.3.2-Beta
+# Archipelago Banjo-Tooie (US-Only) | 3.3.3-Beta
 Banjo Tooie for Archipelago 
 
 # Current Implementation

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Banjo Tooie for Archipelago
 - Cheato Pages
 - Jinjos
 - Glowbos
-- Moves from Jamjars
+- Moves from Jamjars, Roysten & Amaze-O-Gaze
 - Doubloons
 - Treble Clef
 - Train Switches
@@ -45,6 +45,7 @@ Banjo Tooie for Archipelago
  - Dpad right + L: Super Banjo
  - Dpad down + L: Health Regen
  - Dpad left + L: Aim Assist 
+ - L + Start: Smooth Banjo (increases in-game fps)
 
 ## Quality of life
 - Skip Jiggywiggy puzzles to open levels
@@ -52,10 +53,12 @@ Banjo Tooie for Archipelago
 - Skippable Tower of Tragedy
 - Prison code door is always open
 - Skip rounds of the longer minigames
+- Skip Klungo 1 & 2
 
 ## Others
 - Death Link
 - Random level Order (requires some items randomized and puzzle skips)
+- Random level Entrances
 - Change how Eggs works (YAML Option)
 
 # How to install

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -15,7 +15,7 @@ local math = require('math')
 require('common')
 
 local SCRIPT_VERSION = 4
-local BT_VERSION = "V3.3.2"
+local BT_VERSION = "V3.3.3"
 local PLAYER = ""
 local SEED = 0
 

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -57,7 +57,7 @@ bt_loc_name_to_id = network_data_package["games"]["Banjo-Tooie"]["location_name_
 bt_itm_name_to_id = network_data_package["games"]["Banjo-Tooie"]["item_name_to_id"]
 
 script_version: int = 4
-version: str = "V3.3.2"
+version: str = "V3.3.3"
 
 def get_item_value(ap_id):
     return ap_id

--- a/worlds/banjo_tooie/Options.py
+++ b/worlds/banjo_tooie/Options.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from Options import Toggle, DeathLink, PerGameCommonOptions, Choice, DefaultOnToggle, Range, StartInventoryPool
 
 class EnableMultiWorldMoveList(DefaultOnToggle):
-    """Jamjars' Movelist is locked between the MultiWorld. Other players need to unlock Banjo's Moves."""
+    """Jamjars & Roysten Movelist are locked between the MultiWorld. Other players need to unlock Banjo's Moves."""
     display_name = "Jamjars' Movelist"
 
 class EnableMultiWorldBKMoveList(Choice):
@@ -136,10 +136,10 @@ class SkipToT(Choice):
 class LogicType(Choice):
     """Choose your logic difficulty and difficulty of tricks you are expected to perform to reach certain areas."""
     display_name = "Logic Type"
-    option_beginner = 0
-    option_normal = 1
-    option_advanced = 2
-    option_glitched = 3
+    option_intended = 0
+    option_easy_tricks = 1
+    option_hard_tricks = 2
+    option_glitches = 3
     default = 0
 
 class Silos(Choice):

--- a/worlds/banjo_tooie/Regions.py
+++ b/worlds/banjo_tooie/Regions.py
@@ -696,7 +696,7 @@ def connect_regions(self):
                          regionName.CCLE: lambda state: rules.ccl_jiggy(state)})
     
     region_TL = multiworld.get_region(regionName.TL, player)
-    region_TL.add_exits({regionName.TL_HATCH, regionName.WW, regionName.CHUFFY, regionName.IOHWL},
+    region_TL.add_exits({regionName.TL_HATCH, regionName.WW, regionName.CHUFFY},
                         {regionName.WW: lambda state: rules.TDL_to_WW(state),
                          regionName.CHUFFY: lambda state: rules.can_beat_king_coal(state) and rules.tdl_to_chuffy(state),
                          regionName.TL_HATCH: lambda state: rules.long_jump(state),

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -413,7 +413,7 @@ class BanjoTooieRules:
         self.glowbo_rules = {
             locationName.GLOWBOMT2: lambda state: self.can_access_JSG(state),
 
-            locationName.GLOWBOGM1: lambda state: self.GGM_slope(state),
+            locationName.GLOWBOGM1: lambda state: self.glowbo_entrance_ggm(state),
 
             locationName.GLOWBOWW1: lambda state: self.glowbo_inferno(state),
             locationName.GLOWBOWW2: lambda state: self.glowbo_wigwam(state),
@@ -761,7 +761,7 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = self.slightly_elevated_ledge(state)\
-                  and self.stiltStride(state) and self.prison_compound_open(state)
+                  and self.stiltStride(state) and self.prison_compound_open(state) and self.tall_jump(state)
         elif self.world.options.logic_type == 1: # normal
             logic = self.slightly_elevated_ledge(state)\
                   and self.stiltStride(state) and self.prison_compound_open(state)
@@ -776,7 +776,7 @@ class BanjoTooieRules:
     def jiggy_pillars(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.bill_drill(state) and (self.dive(state) or self.slightly_elevated_ledge(state))\
+            logic = self.bill_drill(state) and (self.dive(state) or self.slightly_elevated_ledge(state) and self.tall_jump(state))\
                     and self.small_elevation(state) and self.prison_compound_open(state)
         elif self.world.options.logic_type == 1: # normal
             logic = self.bill_drill(state) and self.small_elevation(state) and self.prison_compound_open(state)\
@@ -2165,7 +2165,7 @@ class BanjoTooieRules:
     def cheato_prison(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.prison_compound_open(state) and self.slightly_elevated_ledge(state)
+            logic = self.prison_compound_open(state) and self.slightly_elevated_ledge(state) and self.tall_jump(state)
         elif self.world.options.logic_type == 1: # normal
             logic = self.prison_compound_open(state) and self.slightly_elevated_ledge(state)
         elif self.world.options.logic_type == 2: # advanced
@@ -2494,6 +2494,18 @@ class BanjoTooieRules:
             logic = self.check_mumbo_magic(state, itemName.MUMBOMT)
         elif self.world.options.logic_type == 3: # glitched
             logic = self.glitchedJSGAccess(state)
+        return logic
+    
+    def glowbo_entrance_ggm(self, state: CollectionState) -> bool:
+        logic = True
+        if self.world.options.logic_type == 0: # beginner
+            logic = self.GGM_slope(state)
+        elif self.world.options.logic_type == 1: # normal
+            logic = self.GGM_slope(state)
+        elif self.world.options.logic_type == 2: # advanced
+            logic = self.GGM_slope(state) or self.clockwork_shot(state)
+        elif self.world.options.logic_type == 3: # glitched
+            logic = self.GGM_slope(state) or self.clockwork_shot(state)
         return logic
 
     def glowbo_inferno(self, state: CollectionState) -> bool:
@@ -3542,9 +3554,9 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 1: # normal
             logic = self.small_elevation(state) or self.ggm_trot(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.small_elevation(state) or self.ggm_trot(state)
+            logic = self.small_elevation(state) or self.ggm_trot(state) or self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.small_elevation(state) or self.ggm_trot(state)
+            logic = self.small_elevation(state) or self.ggm_trot(state) or self.clockwork_shot(state)
         return logic
 
     
@@ -4821,6 +4833,7 @@ class BanjoTooieRules:
                 self.shack_pack(state)) and \
                 self.breegull_blaster(state) and \
                 self.clockwork_eggs(state)\
+                and self.can_shoot_linear_egg(state)\
                 and (self.talon_trot(state) and self.tall_jump(state))
         elif self.world.options.logic_type == 1: # normal
             return enough_jiggies and \
@@ -4828,6 +4841,7 @@ class BanjoTooieRules:
                 self.shack_pack(state)) and \
                 self.breegull_blaster(state) and \
                 self.clockwork_eggs(state)\
+                and self.can_shoot_linear_egg(state)\
                 and (self.talon_trot(state) or self.tall_jump(state))
         elif self.world.options.logic_type == 2: # advanced
             return enough_jiggies and \

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -1786,11 +1786,11 @@ class BanjoTooieRules:
                     and (self.wing_whack(state) or self.blue_eggs(state) or self.fire_eggs(state) or self.ice_eggs(state))
         elif self.world.options.logic_type == 2: # advanced
             logic = self.split_up(state)\
-                    and (self.flight_pad(state) or self.glide(state) or (self.tall_jump(state) and self.wing_whack(state)))\
+                    and (self.flight_pad(state) or self.glide(state) or ((self.tall_jump(state) or self.leg_spring(state)) and self.wing_whack(state)))\
                     and (self.wing_whack(state) or self.blue_eggs(state) or self.fire_eggs(state) or self.ice_eggs(state))
         elif self.world.options.logic_type == 3: # glitched
             logic = self.split_up(state)\
-                    and (self.flight_pad(state) or self.glide(state) or (self.tall_jump(state) and self.wing_whack(state)))\
+                    and (self.flight_pad(state) or self.glide(state) or ((self.tall_jump(state) or self.leg_spring(state)) and self.wing_whack(state)))\
                     and (self.wing_whack(state) or self.blue_eggs(state) or self.fire_eggs(state) or self.ice_eggs(state))
         return logic
     
@@ -3049,7 +3049,7 @@ class BanjoTooieRules:
         if self.world.options.logic_type == 0: # beginner
             logic = self.wonderwing(state) and self.flap_flip(state) and self.long_jump(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = True
+            logic = self.wonderwing(state) and self.flap_flip(state) and self.long_jump(state)
         elif self.world.options.logic_type == 2: # advanced
             logic = True
         elif self.world.options.logic_type == 3: # glitched
@@ -3118,12 +3118,12 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 2: # advanced
             logic = self.shack_pack(state) and self.climb(state) and (self.tall_jump(state) or self.pack_whack(state))\
                     or self.split_up(state)\
-                        and (self.flight_pad(state) or self.glide(state) or (self.wing_whack(state) and self.tall_jump(state)))\
+                        and (self.flight_pad(state) or self.glide(state) or ((self.tall_jump(state) or self.leg_spring(state)) and self.wing_whack(state)))\
                         and (self.leg_spring(state) or (self.glide(state) and self.tall_jump(state) or self.clockwork_shot(state)))
         elif self.world.options.logic_type == 3: # glitched
             logic = self.shack_pack(state) and self.climb(state) and (self.tall_jump(state) or self.pack_whack(state))\
                     or self.split_up(state)\
-                        and (self.flight_pad(state) or self.glide(state) or (self.wing_whack(state) and self.tall_jump(state)))\
+                        and (self.flight_pad(state) or self.glide(state) or ((self.tall_jump(state) or self.leg_spring(state)) and self.wing_whack(state)))\
                         and (self.leg_spring(state) or (self.glide(state) and self.tall_jump(state) or self.clockwork_shot(state)))
         return logic
 
@@ -3822,7 +3822,6 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 1: # normal
             logic = self.flight_pad(state)\
                     or self.climb(state) and (self.long_jump(state) or self.grip_grab(state) or self.pack_whack(state) or self.sack_pack(state))\
-                    or self.leg_spring(state) and (self.glide(state) or self.wing_whack(state))\
                     or state.has(itemName.HUMBACC, self.player)
         elif self.world.options.logic_type == 2: # advanced
             logic = self.flight_pad(state)\

--- a/worlds/banjo_tooie/WorldOrder.py
+++ b/worlds/banjo_tooie/WorldOrder.py
@@ -199,7 +199,7 @@ def handle_early_moves(world: BanjoTooieWorld) -> None:
             world.multiworld.early_items[world.player][itemName.TRAINSWGI] = 1
             world.multiworld.early_items[world.player][itemName.CLIMB] = 1
             world.multiworld.early_items[world.player][itemName.TRAINSWIH] = 1
-            world.multiworld.early_items[world.player][random.choice([itemName.FFLIP, itemName.TTROT, itemName.TJUMP])] = 1
+            world.multiworld.early_items[world.player][world.random.choice([itemName.FFLIP, itemName.TTROT, itemName.TJUMP])] = 1
 
         if actual_first_level == regionName.HP:
             move_lst = [itemName.TJUMP, itemName.FFLIP, itemName.TTROT]
@@ -214,7 +214,7 @@ def handle_early_moves(world: BanjoTooieWorld) -> None:
 def early_fire_eggs(world: BanjoTooieWorld) -> None:
     world.multiworld.early_items[world.player][itemName.PBEGGS if world.options.egg_behaviour.value == 2 else itemName.FEGGS] = 1
     if world.options.randomize_bk_moves != 0:
-        world.multiworld.early_items[world.player][random.choice([itemName.EGGAIM, itemName.EGGSHOOT])] = 1
+        world.multiworld.early_items[world.player][world.random.choice([itemName.EGGAIM, itemName.EGGSHOOT])] = 1
 
 def early_torpedo(world: BanjoTooieWorld) -> None:
     if world.options.randomize_bk_moves != 0:

--- a/worlds/banjo_tooie/WorldOrder.py
+++ b/worlds/banjo_tooie/WorldOrder.py
@@ -134,14 +134,14 @@ def choose_unlocked_silos(world: BanjoTooieWorld) -> None:
     if not world.options.randomize_bk_moves.value == 2 and world.options.open_silos.value == 0:
         world.single_silo = "NONE"
 
-    elif world.options.randomize_bk_moves.value == 2 and world.options.open_silos.value == 0 and world.options.randomize_worlds.value == 0:
+    elif world.options.randomize_bk_moves.value == 2 and world.options.randomize_worlds.value == 0 and world.options.open_silos.value == 0:
         world.single_silo = "NONE"
         
     elif world.options.open_silos.value == 2:
         world.single_silo = "ALL"
 
-    elif world.options.randomize_bk_moves.value == 2 and world.options.randomize_worlds.value == 1:
-        # One silo is necessary to make decent progress in the overworld, so we pick the one that's the closest to the first world.
+    elif world.options.randomize_bk_moves.value == 2 and world.options.randomize_worlds.value == 1 or world.options.open_silos.value == 1:
+        # One silo chosen or imposed.
 
         if list(world.randomize_order.keys())[0] == regionName.GIO:
             # GI is special. If loading zones are not randomized, the only way to make progress in the level is by riding the train into the level from Cliff Top.
@@ -158,11 +158,6 @@ def choose_unlocked_silos(world: BanjoTooieWorld) -> None:
                 regionName.CK: regionName.IOHQM,
             }
             world.single_silo = overworld_lookup[list(world.randomize_order.keys())[0]]
-
-    elif not (world.options.randomize_worlds.value == 1 and world.options.randomize_bk_moves.value == 2) and world.options.open_silos.value == 1:
-        # No requirement for a specific silo, and the player wants one, so we pick one at random.
-        world.single_silo = world.random.choice([regionName.IOHPL, regionName.IOHPG, regionName.IOHCT, regionName.IOHQM])
-
     else:
         raise ValueError("These settings were not considered when randomizing loading zones. Please give us your settings so that we fix it.")
 
@@ -170,19 +165,20 @@ def handle_early_moves(world: BanjoTooieWorld) -> None:
     first_level = list(world.randomize_worlds.keys())[0]
     actual_first_level = world.loading_zones[first_level]
 
-    # A silo to the first world is not guaranteed.
-    if world.options.randomize_bk_moves != 2 and world.single_silo != "ALL":
+    # A silo to the first world is not given.
+    if world.options.randomize_bk_moves != 2 and world.single_silo == "NONE":
         if  first_level != regionName.MT and world.options.logic_type != 2:
             world.multiworld.early_items[world.player][itemName.GGRAB] = 1
-        if  first_level == regionName.WW:
-            early_fire_eggs(world)
-        if  first_level == regionName.JR or first_level == regionName.HP:
-            world.multiworld.early_items[world.player][itemName.SPLITUP] = 1
-        if first_level == regionName.TL or first_level == regionName.CC:
-            early_fire_eggs(world)
-            early_torpedo(world)
-        if first_level == regionName.CK: # CK can't be first if progressive shoes.
-            world.multiworld.early_items[world.player][itemName.CLAWBTS] = 1
+
+            if  first_level == regionName.WW:
+                early_fire_eggs(world)
+            if  first_level == regionName.JR or first_level == regionName.HP:
+                world.multiworld.early_items[world.player][itemName.SPLITUP] = 1
+            if first_level == regionName.TL or first_level == regionName.CC:
+                early_fire_eggs(world)
+                early_torpedo(world)
+            if first_level == regionName.CK: # CK can't be first if progressive shoes.
+                world.multiworld.early_items[world.player][itemName.CLAWBTS] = 1
 
     if world.options.randomize_bk_moves == 2: # Guaranteed silo to first level, but getting enough stuff in levels is still hard sometimes.
         # MT, GGM, WW Easy

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -604,7 +604,7 @@ class BanjoTooieWorld(World):
     def fill_slot_data(self) -> Dict[str, Any]:
         btoptions = {}
         btoptions["player_name"] = self.multiworld.player_name[self.player]
-        btoptions["seed"] = self.random.randint(12212, 69996)
+        btoptions["seed"] = self.random.randint(12212, 9090763)
         btoptions["deathlink"] = "true" if self.options.death_link.value == 1 else "false"
         btoptions["activate_text"] = "true" if self.options.activate_overlay_text.value == 1 else "false"
         btoptions['text_colour'] = int(self.options.overlay_text_colour.value)

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -74,7 +74,7 @@ class BanjoTooieWorld(World):
     options: BanjoTooieOptions
 
     def __init__(self, world, player):
-        self.version = "V3.3.2"
+        self.version = "V3.3.3"
         self.kingjingalingjiggy = False
         self.starting_egg: int = 0
         self.starting_attack: int = 0
@@ -590,17 +590,16 @@ class BanjoTooieWorld(World):
             regionName.CK: regionName.IOHQM + " (Caudron Keep Entrance)"
         }
         bt_players = world.get_game_players(cls.game)
-        spoiler_handle.write('\n\nBanjo-Tooie Loading Zones:')
+        # spoiler_handle.write('\n\nBanjo-Tooie')
         for player in bt_players:
             name = world.get_player_name(player)
-            spoiler_handle.write(f"\n\n({name})")
+            spoiler_handle.write(f"\n\nBanjo-Tooie ({name}):")
+            spoiler_handle.write('\n\tVersion: ' + world.worlds[player].version)
+            spoiler_handle.write('\n\tLoading Zones:')
             for starting_zone, actual_world in world.worlds[player].loading_zones.items():
-                    spoiler_handle.write(f"\n{entrance_hags[starting_zone]} -> {actual_world}")
-
-        spoiler_handle.write('\n\nBanjo-Tooie Silo:\n\n')
-        for player in bt_players:
-            name = world.get_player_name(player)
-            spoiler_handle.write("{}: {}\n".format(name, world.worlds[player].single_silo))
+                    spoiler_handle.write(f"\n\t\t{entrance_hags[starting_zone]} -> {actual_world}")
+            spoiler_handle.write('\n\tBanjo-Tooie Silo:\n')
+            spoiler_handle.write("\t\t"+world.worlds[player].single_silo)
 
     def fill_slot_data(self) -> Dict[str, Any]:
         btoptions = {}

--- a/worlds/banjo_tooie/docs/en_Banjo-Tooie.md
+++ b/worlds/banjo_tooie/docs/en_Banjo-Tooie.md
@@ -15,7 +15,7 @@ Use the Dpad to display unlocked elements that the Pause Menu doesn't display (M
 
 - Jiggies
 - Treble Clefs
-- Jamjar Moves + Amaze-O-Gaze
+- Jamjar Moves + Amaze-O-Gaze + Roysten
 - Empty Honeycombs
 - Cheato Pages
 - Glowbos


### PR DESCRIPTION
# 3.3.3-beta
 - If you choose to have 1 silo open, your first silo will now always lead to the first level (unless Mayahem Temple is your first level. In which case, The silo is randomly selected).
 - Logic Fixes:
   - Prison Compound Cheato Page: For beginner logic, you need tall jump to jump from the water to the platforms.
   - Prison Compound Jiggy: For beginner logic, you need tall jump to jump from the water to the platforms.
   - MT Pillars Jiggy: For beginner logic, you need tall jump to jump from the water to the platforms, if going through the top of Prison Compound.
   - GGM Entrance Glowbo: for advanced and glitched logic, can be gotten with a clockwork.
   - Back-left Fuel Depot Note: for advanced and glitched logic, can be gotten with a clockwork.
   - TDL to Wasteland: fixed the broken transition.
   - Hot Waterfall Jinjo: removed the damage boost from normal logic.
   - Sack Race Note: removed Leg Spring + (Wing Whack or glide) from normal logic.
   - Trash Can Jiggy and Jinjo: Added Leg Spring + Wing Whack as an option to reach the Trash Can, in advanced and glitched logic.
   - Defeating Hag 1: beginner and normal logic get a 2nd type of egg to help with damaging.
  - Logic names are now: Intended / Easy Tricks / Hard Tricks / Glitches