### PR TITLE
Pre alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.apworld
 *.zip
+*.py

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,20 @@
+# 3.5.3-beta
+  - Logic Fixes:
+    - Treasure Chamber Jiggy: added condition to make sure you can reach the treasure chamber.
+    - GGM Entrance Glowbo: In hard tricks and glitches logics, can be gotten with nothing by jumping on the right side of the slope.
+    - GGM Mumbo Notes: if not on intended logic, can be gotten with turbo trainers or springy step shoes.
+    - Alcove Doubloons: For hard tricks and glitch logics, can be gotten with:
+      - Pack Whack + Tall Jump + Grip Grab
+      - Tall Jump + Wing Whack
+      - Tall Jump + Glide
+    - Chompa Jiggy: For hard tricks and glitch logics, added beak buster as a way to reach the flight pad.
+    - Glitched access to the top of TDL: if going through the insides of the mountain, requires tall jump, grip grab, or beak buster to reach the flight pad.
+    - GI Train station honeycomb: if not on intended logic, can be gotten with leg spring.
+    - Air Conditionning Plant Note 2: in intended logic, added moves to cross the gap.
+    - Dragon Brothers jiggy: added moves to jump over the tongue
+    - CCL Humba Jinjo: Uses logic that was meant to be in use for the past 2 months. Oops!
+      - From the logs from 3.0-beta: "can be gotten with leg spring, if not on beginner logic. Advanced and glitched logic can get it with a clockwork shot."
+
 # 3.5.2-beta
   - Renamings:
     - Area 51 notes: renamed to left and right notes.
@@ -21,7 +38,7 @@
     - Central Cavern Jinjo: No longer needs bill drill on advanced and glitched logic. You can use the shoes near the split up pads
 
 # 3.5.1-beta
-  -Logic fixes:
+  - Logic fixes:
     - Treasure Chamber Jiggy: checks if you have talon trot, if you're reaching the top from the inside. Also, if not on intended logic, takes getting the relic from TDL into consideration.
     - Snake Head Cheato Page: Checks if you have talon trot, if you're reaching the top from the inside. For intended logic, no longer requires egg aim if reaching it by flight.
     - Plateau to GGM: For GGM early, doing it with talon trot + air rat-a-tat rap + beak buster is no longer in logic.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # 3.5.3-beta
   - Logic Fixes:
+    - MT Honeycomb: takes glitched access into JSG into account for the stony.
     - Treasure Chamber Jiggy: added condition to make sure you can reach the treasure chamber.
     - GGM Entrance Glowbo: In hard tricks and glitches logics, can be gotten with nothing by jumping on the right side of the slope.
     - GGM Mumbo Notes: if not on intended logic, can be gotten with turbo trainers or springy step shoes.
@@ -12,6 +13,7 @@
     - GI Train station honeycomb: if not on intended logic, can be gotten with leg spring.
     - Air Conditionning Plant Note 2: in intended logic, added moves to cross the gap.
     - Dragon Brothers jiggy: added moves to jump over the tongue
+    - HFP Kickball Jiggy: takes glitched access into JSG into account for the stony.
     - CCL Humba Jinjo: Uses logic that was meant to be in use for the past 2 months. Oops!
       - From the logs from 3.0-beta: "can be gotten with leg spring, if not on beginner logic. Advanced and glitched logic can get it with a clockwork shot."
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@
     - HFP Kickball Jiggy: takes glitched access into JSG into account for the stony.
     - CCL Humba Jinjo: Uses logic that was meant to be in use for the past 2 months. Oops!
       - From the logs from 3.0-beta: "can be gotten with leg spring, if not on beginner logic. Advanced and glitched logic can get it with a clockwork shot."
+  - Fix UT getting accurate counts for Notes and Jiggies
+  - BTClient allows CLI but untested with arguments (jjjj12212's evironment isn't able to...)
 
 # 3.5.2-beta
   - Renamings:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Archipelago Banjo-Tooie (US-Only) | 3.5.2-Beta
+# Archipelago Banjo-Tooie (US-Only) | 3.5.3-Beta
 Banjo Tooie for Archipelago 
 
 # Current Implementation

--- a/data/lua/banjo_tooie_connector.lua
+++ b/data/lua/banjo_tooie_connector.lua
@@ -15,7 +15,7 @@ local math = require('math')
 require('common')
 
 local SCRIPT_VERSION = 4
-local BT_VERSION = "V3.5.2"
+local BT_VERSION = "V3.5.3"
 local PLAYER = ""
 local SEED = 0
 

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -58,7 +58,7 @@ bt_loc_name_to_id = network_data_package["games"]["Banjo-Tooie"]["location_name_
 bt_itm_name_to_id = network_data_package["games"]["Banjo-Tooie"]["item_name_to_id"]
 
 script_version: int = 4
-version: str = "V3.5.2"
+version: str = "V3.5.3"
 
 def get_item_value(ap_id):
     return ap_id

--- a/worlds/banjo_tooie/BTClient.py
+++ b/worlds/banjo_tooie/BTClient.py
@@ -5,6 +5,7 @@ import multiprocessing
 import copy
 import random
 import subprocess
+import sys
 import time
 from typing import Union
 import zipfile
@@ -789,7 +790,10 @@ async def n64_sync_task(ctx: BanjoTooieContext):
 def main():
     Utils.init_logging("Banjo-Tooie Client")
     parser = get_base_parser()
-    args = parser.parse_args()
+    args = sys.argv[1:]  # the default for parse_args()
+    if "Banjo-Tooie Client" in args:
+        args.remove("Banjo-Tooie Client")
+    args = parser.parse_args(args)
 
     async def _main():
         multiprocessing.freeze_support()

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -481,7 +481,7 @@ class BanjoTooieRules:
             locationName.PACKWH: lambda state: self.split_up(state) and self.check_notes(state, 170),
 
             locationName.AUQAIM: lambda state: (self.has_explosives(state) or state.has(itemName.DOUBLOON, self.player, 28)) and
-                                               self.check_notes(state, 285),
+                                               self.check_notes(state, 275),
             locationName.TTORP: lambda state:  self.can_reach_atlantis(state) and self.grip_grab(state) and self.tall_jump(state) and
                                                self.check_notes(state, 290),
             locationName.WWHACK: lambda state: (self.has_explosives(state)) and self.split_up(state) and
@@ -1755,16 +1755,16 @@ class BanjoTooieRules:
     def jiggy_hfp_kickball(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.check_mumbo_magic(state, itemName.MUMBOMT) and self.has_explosives(state)
+            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.can_access_JSG(state) and self.has_explosives(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.check_mumbo_magic(state, itemName.MUMBOMT) and \
+            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.can_access_JSG(state) and \
                     (self.has_explosives(state) or \
                     self.check_mumbo_magic(state, itemName.MUMBOHP))
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.check_mumbo_magic(state, itemName.MUMBOMT) and \
+            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.can_access_JSG(state) and \
                     (self.has_explosives(state) or self.check_mumbo_magic(state, itemName.MUMBOHP))
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.check_mumbo_magic(state, itemName.MUMBOMT) and \
+            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.can_access_JSG(state) and \
                     (self.has_explosives(state) or self.check_mumbo_magic(state, itemName.MUMBOHP))
         return logic
     
@@ -1913,15 +1913,15 @@ class BanjoTooieRules:
     def honeycomb_mt_entrance(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == 0: # beginner
-            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.check_mumbo_magic(state, itemName.MUMBOMT)
+            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.can_access_JSG(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = (self.check_humba_magic(state, itemName.HUMBAMT) and self.check_mumbo_magic(state, itemName.MUMBOMT)) or \
+            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.can_access_JSG(state) or \
                     self.clockwork_eggs(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = (self.check_humba_magic(state, itemName.HUMBAMT) and self.check_mumbo_magic(state, itemName.MUMBOMT)) or \
+            logic = self.check_humba_magic(state, itemName.HUMBAMT) and self.can_access_JSG(state) or \
                     self.clockwork_eggs(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.check_humba_magic(state, itemName.HUMBAMT) and self.check_mumbo_magic(state, itemName.MUMBOMT))\
+            logic = self.can_access_JSG(state) and self.check_humba_magic(state, itemName.HUMBAMT)\
                     or self.clockwork_eggs(state)\
                     or self.breegull_bash(state)
                     

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -215,7 +215,7 @@ class BanjoTooieRules:
             locationName.TRAINSWHP1: lambda state: self.tswitch_lavaside(state),
             locationName.TRAINSWWW: lambda state: self.tswitch_ww(state),
             locationName.TRAINSWTD: lambda state: self.tswitch_tdl(state),
-            #locationName.TRAINSWGI: lambda state: self.tswitch_gi(state),
+            #locationName.TRAINSWGI: lambda state: self.tswitch_gi(state), This rules isn't necessary anymore, it's in GIOB
         }
 
         self.jiggy_chunks_rules = {
@@ -553,7 +553,7 @@ class BanjoTooieRules:
             locationName.JINJOCC1: lambda state: self.jinjo_trash_can(state),
             locationName.JINJOCC2: lambda state: self.jinjo_cheese(state),
             locationName.JINJOCC3: lambda state: self.jinjo_central(state),
-            locationName.JINJOCC5: lambda state: self.climb(state) or state.has(itemName.HUMBACC, self.player),
+            locationName.JINJOCC5: lambda state: self.jinjo_humba_ccl(state),
         }
 
         self.notes_rules = {
@@ -618,6 +618,7 @@ class BanjoTooieRules:
             locationName.NOTEGI9:   lambda state: self.notes_short_stack(state),
             locationName.NOTEGI11:  lambda state: self.notes_waste_disposal(state),
             locationName.NOTEGI12:  lambda state: self.notes_waste_disposal(state),
+            locationName.NOTEGI13:  lambda state: self.notes_aircon_hard(state),
             locationName.NOTEGI15:  lambda state: self.notes_floor_3(state),
             locationName.NOTEGI16:  lambda state: self.notes_floor_3(state),
 
@@ -730,20 +731,23 @@ class BanjoTooieRules:
                 (self.flap_flip(state) or self.slightly_elevated_ledge(state)) and\
                   ((self.grip_grab(state) and self.spring_pad(state) and self.flap_flip(state) and self.talon_trot(state)) or self.MT_flight_pad(state))
         elif self.world.options.logic_type == 1: # normal
-            logic = (self.flap_flip(state) or self.slightly_elevated_ledge(state)) and\
-                  ((self.grip_grab(state) and self.spring_pad(state) and self.flap_flip(state) and self.egg_aim(state) and self.talon_trot(state))\
-                    or (self.MT_flight_pad(state) and self.can_shoot_any_egg(state))\
-                    or state.can_reach_region(regionName.TL_HATCH, self.player))
+            logic = (self.flap_flip(state) or self.slightly_elevated_ledge(state))\
+                    and ((self.grip_grab(state) and self.spring_pad(state) and self.flap_flip(state) and self.egg_aim(state) and self.talon_trot(state))\
+                        or (self.MT_flight_pad(state) and self.can_shoot_any_egg(state))\
+                        or state.can_reach_region(regionName.TL_HATCH, self.player))\
+                    and (self.MT_flight_pad(state) and self.can_shoot_any_egg(state) or self.egg_aim(state))
         elif self.world.options.logic_type == 2: # advanced
-            logic = (self.flap_flip(state) or self.slightly_elevated_ledge(state)) and\
-                  ((self.grip_grab(state) and self.spring_pad(state) and self.flap_flip(state) and self.egg_aim(state) and self.talon_trot(state))\
-                    or (self.MT_flight_pad(state) and self.can_shoot_any_egg(state))\
-                    or state.can_reach_region(regionName.TL_HATCH, self.player))
+            logic = (self.flap_flip(state) or self.slightly_elevated_ledge(state))\
+                    and ((self.grip_grab(state) and self.spring_pad(state) and self.flap_flip(state) and self.egg_aim(state) and self.talon_trot(state))\
+                        or (self.MT_flight_pad(state) and self.can_shoot_any_egg(state))\
+                        or state.can_reach_region(regionName.TL_HATCH, self.player))\
+                    and (self.MT_flight_pad(state) and self.can_shoot_any_egg(state) or self.egg_aim(state))
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.flap_flip(state) or self.slightly_elevated_ledge(state)) and\
-                  ((self.grip_grab(state) and self.spring_pad(state) and self.flap_flip(state) and self.egg_aim(state) and self.talon_trot(state))\
-                    or (self.MT_flight_pad(state) and self.can_shoot_any_egg(state))\
-                    or state.can_reach_region(regionName.TL_HATCH, self.player))
+            logic = (self.flap_flip(state) or self.slightly_elevated_ledge(state))\
+                    and ((self.grip_grab(state) and self.spring_pad(state) and self.flap_flip(state) and self.egg_aim(state) and self.talon_trot(state))\
+                        or (self.MT_flight_pad(state) and self.can_shoot_any_egg(state))\
+                        or state.can_reach_region(regionName.TL_HATCH, self.player))\
+                    and (self.MT_flight_pad(state) and self.can_shoot_any_egg(state) or self.egg_aim(state))
         return logic
     
 
@@ -1395,13 +1399,13 @@ class BanjoTooieRules:
             )
         elif self.world.options.logic_type == 2: # advanced
             logic = self.breegull_blaster(state) and (
-                ((self.tall_jump(state) or self.grip_grab(state)) and self.flight_pad(state)
+                ((self.tall_jump(state) or self.grip_grab(state) or self.beak_buster(state)) and self.flight_pad(state)
                  or (self.egg_aim(state) and self.has_explosives(state) and self.springy_step_shoes(state))
                  or (self.springy_step_shoes(state) and self.veryLongJump(state)))
             )
         elif self.world.options.logic_type == 3: # glitched
             logic = self.breegull_blaster(state) and (
-                ((self.tall_jump(state) or self.grip_grab(state)) and self.flight_pad(state)
+                ((self.tall_jump(state) or self.grip_grab(state) or self.beak_buster(state)) and self.flight_pad(state)
                  or (self.egg_aim(state) and self.has_explosives(state) and self.springy_step_shoes(state))
                  or (self.springy_step_shoes(state) and self.veryLongJump(state)))
             )
@@ -1638,22 +1642,26 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == 0: # beginner
             logic = self.fire_eggs(state) and self.ice_eggs(state) and \
-                    self.claw_clamber_boots(state) and self.flight_pad(state) and self.third_person_egg_shooting(state)
+                    self.claw_clamber_boots(state) and self.flight_pad(state) and self.third_person_egg_shooting(state)\
+                    and (self.tall_jump(state) or self.talon_trot(state))
         elif self.world.options.logic_type == 1: # normal
             logic = self.fire_eggs(state) and self.ice_eggs(state) and \
-                    self.claw_clamber_boots(state) and self.flight_pad(state) and self.third_person_egg_shooting(state)
+                    self.claw_clamber_boots(state) and self.flight_pad(state) and self.third_person_egg_shooting(state)\
+                    and (self.tall_jump(state) or self.talon_trot(state))
         elif self.world.options.logic_type == 2: # advanced
             # In case people go for the damage boost for Chilly Willy then die before getting the jiggy, we also require Pack Whack to prevent softlocks.
             logic = self.fire_eggs(state) and self.ice_eggs(state) and self.flight_pad(state) and self.third_person_egg_shooting(state) and \
                     (self.claw_clamber_boots(state)\
                      or (self.pack_whack(state) and self.tall_jump(state) and self.flutter(state) and \
-                         (self.talon_trot(state) or self.flap_flip(state))))
+                         (self.talon_trot(state) or self.flap_flip(state))))\
+                    and (self.tall_jump(state) or self.talon_trot(state))
         elif self.world.options.logic_type == 3: # glitched
             # In case people go for the damage boost for Chilly Willy then die before getting the jiggy, we also require Pack Whack to prevent softlocks.
             logic = self.fire_eggs(state) and self.ice_eggs(state) and self.flight_pad(state) and self.third_person_egg_shooting(state) and \
                     (self.claw_clamber_boots(state)\
                      or (self.pack_whack(state) and self.tall_jump(state) and self.flutter(state) and \
-                         (self.talon_trot(state) or self.flap_flip(state))))
+                         (self.talon_trot(state) or self.flap_flip(state))))\
+                    and (self.tall_jump(state) or self.talon_trot(state))
         return logic
     
     def jiggy_volcano(self, state: CollectionState) -> bool:
@@ -2134,9 +2142,9 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 1: # normal
             logic = self.ground_attack(state) and self.spring_pad(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = (self.ground_attack(state) and self.spring_pad(state)) or self.clockwork_shot(state)
+            logic = (self.ground_attack(state) and self.spring_pad(state)) or self.clockwork_shot(state) or self.leg_spring(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = (self.ground_attack(state) and self.spring_pad(state)) or self.clockwork_shot(state)
+            logic = (self.ground_attack(state) and self.spring_pad(state)) or self.clockwork_shot(state) or self.leg_spring(state)
         return logic
 
     def honeycomb_volcano(self, state: CollectionState) -> bool:
@@ -2612,9 +2620,9 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 1: # normal
             logic = self.GGM_slope(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.GGM_slope(state) or self.clockwork_shot(state)
+            logic = True
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.GGM_slope(state) or self.clockwork_shot(state)
+            logic = True
         return logic
 
     def glowbo_inferno(self, state: CollectionState) -> bool:
@@ -3534,11 +3542,21 @@ class BanjoTooieRules:
                     and (self.spring_pad(state) or self.leg_spring(state))
         elif self.world.options.logic_type == 2: # advanced
             logic = (self.split_up(state) and self.has_explosives(state)\
-                        and (self.spring_pad(state) or self.leg_spring(state)))\
+                        and (self.spring_pad(state)\
+                             or self.leg_spring(state)\
+                             or self.pack_whack(state) and self.tall_jump(state) and self.grip_grab(state))\
+                             or self.glide(state) and self.tall_jump(state)\
+                             or self.wing_whack(state) and self.tall_jump(state)
+                        )\
                     or self.clockwork_shot(state)
         elif self.world.options.logic_type == 3: # glitched
             logic = (self.split_up(state) and self.has_explosives(state)\
-                        and (self.spring_pad(state) or self.leg_spring(state)))\
+                        and (self.spring_pad(state)\
+                             or self.leg_spring(state)\
+                             or self.pack_whack(state) and self.tall_jump(state) and self.grip_grab(state))\
+                             or self.glide(state) and self.tall_jump(state)\
+                             or self.wing_whack(state) and self.tall_jump(state)
+                        )\
                     or self.clockwork_shot(state)
         return logic
     
@@ -3716,11 +3734,11 @@ class BanjoTooieRules:
         if self.world.options.logic_type == 0: # beginner
             logic = self.small_elevation(state)
         elif self.world.options.logic_type == 1: # normal
-            logic = self.small_elevation(state) or self.grip_grab(state) or self.beak_buster(state)
+            logic = self.small_elevation(state) or self.grip_grab(state) or self.beak_buster(state) or self.ggm_trot(state)
         elif self.world.options.logic_type == 2: # advanced
-            logic = self.small_elevation(state) or self.grip_grab(state) or self.clockwork_shot(state) or self.beak_buster(state)
+            logic = self.small_elevation(state) or self.grip_grab(state) or self.clockwork_shot(state) or self.beak_buster(state) or self.ggm_trot(state)
         elif self.world.options.logic_type == 3: # glitched
-            logic = self.small_elevation(state) or self.grip_grab(state) or self.clockwork_shot(state) or self.beak_buster(state)
+            logic = self.small_elevation(state) or self.grip_grab(state) or self.clockwork_shot(state) or self.beak_buster(state) or self.ggm_trot(state)
         return logic
     
     def notes_easy_fuel_depot(self, state: CollectionState) -> bool:
@@ -3870,6 +3888,32 @@ class BanjoTooieRules:
                     or self.pack_whack(state) and self.tall_jump(state) and self.climb(state)\
                     or self.leg_spring(state)\
                     or self.clockwork_shot(state)
+        return logic
+
+    # TODO: one of the 3 notes cannot be gotten with grip grab (the one on a big box near a barrel). Which one is that?
+    def notes_gi_train_station(self, state: CollectionState) -> bool:
+        logic = True
+        if self.world.options.logic_type == 0: # beginner
+            logic = self.small_elevation(state) or self.leg_spring(state)
+        elif self.world.options.logic_type == 1: # normal
+            logic = self.small_elevation(state) or self.leg_spring(state) or self.beak_buster(state)
+        elif self.world.options.logic_type == 2: # advanced
+            logic = True
+        elif self.world.options.logic_type == 3: # glitched
+            logic = True
+        return logic
+
+    # Because jumping on a slope is not intended...
+    def notes_aircon_hard(self, state: CollectionState) -> bool:
+        logic = True
+        if self.world.options.logic_type == 0: # beginner
+            logic = self.tall_jump(state) or self.split_up(state) or self.talon_trot(state)
+        elif self.world.options.logic_type == 1: # normal
+            logic = True
+        elif self.world.options.logic_type == 2: # advanced
+            logic = True
+        elif self.world.options.logic_type == 3: # glitched
+            logic = True
         return logic
     
     def notes_leg_spring(self, state: CollectionState) -> bool:
@@ -4328,8 +4372,8 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == 3: # glitched
             return (self.springy_step_shoes(state) or \
                     self.leg_spring(state) and self.glide(state) or\
-                    (self.flight_pad(state) and (self.beak_bomb(state) or\
-                    self.clockwork_warp(state))))
+                    (self.flight_pad(state) and (self.tall_jump(state) or self.beak_buster(state) or self.grip_grab(state))\
+                     and (self.beak_bomb(state) or self.clockwork_warp(state))))
 
     def smuggle_food(self, state: CollectionState) -> bool:
         logic = True

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -16,13 +16,12 @@ from .WorldOrder import WorldRandomize
 from BaseClasses import ItemClassification, Tutorial, Item, Region, MultiWorld
 #from Fill import fill_restrictive
 from worlds.AutoWorld import World, WebWorld
-from worlds.LauncherComponents import Component, components, Type
+from worlds.LauncherComponents import Component, components, Type, launch_subprocess
 
 
 def run_client():
     from worlds.banjo_tooie.BTClient import main  # lazy import
-    p = Process(target=main)
-    p.start()
+    launch_subprocess(main)
 
 components.append(Component("Banjo-Tooie Client", func=run_client, component_type=Type.CLIENT))
 

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -73,7 +73,7 @@ class BanjoTooieWorld(World):
     options: BanjoTooieOptions
 
     def __init__(self, world, player):
-        self.version = "V3.5.2"
+        self.version = "V3.5.3"
         self.kingjingalingjiggy = False
         self.starting_egg: int = 0
         self.starting_attack: int = 0

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -94,23 +94,29 @@ class BanjoTooieWorld(World):
         banjoItem = all_item_table.get(itemname)
         if banjoItem.type == 'progress':
             if banjoItem.btid == 1230515:
-                maxJiggy = max(self.randomize_worlds.values()) if self.randomize_worlds else 70
-                extraJiggys = (90 - maxJiggy)/2
-                if self.jiggy_counter > (maxJiggy+extraJiggys):
-                    item_classification = ItemClassification.filler
-                elif self.jiggy_counter > maxJiggy:
-                    item_classification = ItemClassification.useful
+                if hasattr(self.multiworld, "generation_is_fake") == False: 
+                    maxJiggy = max(self.randomize_worlds.values()) if self.randomize_worlds else 70
+                    extraJiggys = (90 - maxJiggy)/2
+                    if self.jiggy_counter > (maxJiggy+extraJiggys):
+                        item_classification = ItemClassification.filler
+                    elif self.jiggy_counter > maxJiggy:
+                        item_classification = ItemClassification.useful
+                    else:
+                        item_classification = ItemClassification.progression
+                    self.jiggy_counter += 1
                 else:
                     item_classification = ItemClassification.progression
-                self.jiggy_counter += 1
             elif banjoItem.btid == 1230797 and self.options.randomize_notes.value == True:
-                if self.notecounter > 130:
-                    item_classification = ItemClassification.filler
-                elif self.notecounter > 117:
-                    item_classification = ItemClassification.useful
+                if hasattr(self.multiworld, "generation_is_fake") == False:
+                    if self.notecounter > 130:
+                        item_classification = ItemClassification.filler
+                    elif self.notecounter > 117:
+                        item_classification = ItemClassification.useful
+                    else:
+                        item_classification = ItemClassification.progression
+                    self.notecounter += 1
                 else:
                     item_classification = ItemClassification.progression
-                self.notecounter += 1
             else:
                 item_classification = ItemClassification.progression
         if banjoItem.type == 'progression_skip_balancing': #Mumbo Tokens


### PR DESCRIPTION
# 3.5.3-beta
  - Logic Fixes:
    - MT Honeycomb: takes glitched access into JSG into account for the stony.
    - Treasure Chamber Jiggy: added condition to make sure you can reach the treasure chamber.
    - GGM Entrance Glowbo: In hard tricks and glitches logics, can be gotten with nothing by jumping on the right side of the slope.
    - GGM Mumbo Notes: if not on intended logic, can be gotten with turbo trainers or springy step shoes.
    - Alcove Doubloons: For hard tricks and glitch logics, can be gotten with:
      - Pack Whack + Tall Jump + Grip Grab
      - Tall Jump + Wing Whack
      - Tall Jump + Glide
    - Chompa Jiggy: For hard tricks and glitch logics, added beak buster as a way to reach the flight pad.
    - Glitched access to the top of TDL: if going through the insides of the mountain, requires tall jump, grip grab, or beak buster to reach the flight pad.
    - GI Train station honeycomb: if not on intended logic, can be gotten with leg spring.
    - Air Conditionning Plant Note 2: in intended logic, added moves to cross the gap.
    - Dragon Brothers jiggy: added moves to jump over the tongue
    - HFP Kickball Jiggy: takes glitched access into JSG into account for the stony.
    - CCL Humba Jinjo: Uses logic that was meant to be in use for the past 2 months. Oops!
      - From the logs from 3.0-beta: "can be gotten with leg spring, if not on beginner logic. Advanced and glitched logic can get it with a clockwork shot."
  - Fix UT getting accurate counts for Notes and Jiggies
  - BTClient allows CLI but untested with arguments (jjjj12212's evironment isn't able to...)