### PR TITLE
Add option to enable traps/big-o-pants to replace some of the feather and egg nests

### DIFF
--- a/worlds/banjo_tooie/Options.py
+++ b/worlds/banjo_tooie/Options.py
@@ -255,6 +255,14 @@ class EnableMultiWorldDinoRoar(Toggle):
 class EnableNestsanity(Toggle):
     """Eggs and feather nests give checks when you collect them for the first time. They behave as regular egg nests the other times."""
     display_name = "Nestsanity"
+    
+class TrapsToNestRatio(Range):
+    """Replace a percentage of all feather and egg nests items (except golden eggs) to Trap items
+    Requires Traps and Nestsanity to be enabled."""
+    display_name = "Traps to Nests Ratio"
+    range_start = 0
+    range_end = 100
+    default = 0
 
 class KingJingalingHasJiggy(DefaultOnToggle):
     """King Jingaling will always have a Jiggy for you."""
@@ -436,7 +444,8 @@ class BanjoTooieOptions(PerGameCommonOptions):
     randomize_stop_n_swap: RandomizeStopnSwap
     randomize_dino_roar: EnableMultiWorldDinoRoar
     nestsanity: EnableNestsanity
-    traps:Traps
+    traps: Traps
+    traps_nests_ratio: TrapsToNestRatio
 
     randomize_stations: EnableMultiWorldTrainStationSwitches
     randomize_chuffy: EnableMultiWorldChuffyTrain

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -181,6 +181,12 @@ class BanjoTooieWorld(World):
                 i == (self.options.extra_trebleclefs_count.value*3 - 14):
                     break
                 trap_big_pants_counter += 1
+        if self.options.traps_nests_ratio.value > 0:
+            total_nests = 315 + 135
+            removed_nests = int(total_nests * self.options.traps_nests_ratio.value / 100)
+            removed_enests = int(315 * self.options.traps_nests_ratio.value / 100)
+            removed_fnests = removed_nests - removed_enests
+            trap_big_pants_counter += removed_nests
         if self.options.traps.value == True:
             trup = divmod(trap_big_pants_counter, 4)
             ttrap_qty = trup[0] + (1 if trup[1] >= 1 else 0)
@@ -222,7 +228,16 @@ class BanjoTooieWorld(World):
                         for i in range(sqtrap_qty):
                             itempool += [self.create_item(name)]
                     #end of none qty logic
-
+                    
+                    #nests removal for nestsanity and nest traps
+                    elif item.code == 1230806 and self.options.traps_nests_ratio.value > 0:
+                        for i in range(315 - removed_enests):
+                            itempool += [self.create_item(name)]
+                    elif item.code == 1230807 and self.options.traps_nests_ratio.value > 0:
+                        for i in range(135 - removed_fnests):
+                            itempool += [self.create_item(name)]
+                    #end of nest removal for nest traps
+                    
                     #notes - extra other notes
                     elif item.code == 1230797: 
                         count = id.qty
@@ -432,6 +447,8 @@ class BanjoTooieWorld(World):
             raise ValueError("You cannot have progressive bash attack without randomizing Stop N Swap and randomizing BK moves")
         if self.options.randomize_moves == False and self.options.jamjars_silo_costs.value != 0:
             raise ValueError("You cannot change the silo costs without randomizing Jamjars' moves.")
+        if self.options.nestsanity.value == False and self.options.traps_nests_ratio.value > 0:
+            raise ValueError("You cannot have nests as traps without nestsanity.")
         if self.options.open_hag1.value == False and self.options.victory_condition.value == 4:
             self.options.open_hag1.value = True
         if self.options.egg_behaviour.value == 1:

--- a/yaml-template/template.yaml
+++ b/yaml-template/template.yaml
@@ -127,6 +127,7 @@ Banjo-Tooie:
   randomize_dino_roar: 'true' # Roar is in the pool
   nestsanity: 'false'         # Every egg nest and feather nest give a check when you collect them for the first time. They behave as normal afterwards.
   traps: 'false'              # Swaps all Big-O-Pants (junk) items to Traps
+  traps_nests_ratio: 0        # 0 - 100; replaces a percentage of all egg and feather nests (except golden eggs) to Big-O-Pants or trap items. Requires nestsanity.
 
   randomize_stations: 'true'  # adds Stations to the pool
   randomize_chuffy: 'true'    # Chuffy as a AP Item. You can also "call" Chuffy at any unlocked station without needing to fight King Coal.


### PR DESCRIPTION
An equal percentage is removed from both egg and feather nests. Attached an example spoiler log with percentage set to 50

Side note: technically, this can be used to replace them with just Big-O pants items if traps are disabled, but i dunno, some people might be into pants.


[AP_11284445992063899095_Spoiler.txt](https://github.com/user-attachments/files/18310861/AP_11284445992063899095_Spoiler.txt)
