### PR TITLE
Clean up init create items to be more intuitive

### DIFF
--- a/worlds/banjo_tooie/Items.py
+++ b/worlds/banjo_tooie/Items.py
@@ -91,7 +91,7 @@ bk_moves_table = {
 
 progressive_ability_table = {
     itemName.PBBUST:        ItemData(1230828, 2, "progress", ""),
-    itemName.PEGGS:        ItemData(1230829, 4, "progress", ""),
+    itemName.PEGGS:         ItemData(1230829, 4, "progress", ""),
     itemName.PSHOES:        ItemData(1230830, 4, "progress", ""),
     itemName.PSWIM:         ItemData(1230831, 3, "progress", ""),
     itemName.PBASH:         ItemData(1230832, 2, "progress", ""),
@@ -99,6 +99,18 @@ progressive_ability_table = {
     itemName.PEGGAIM:       ItemData(1230783, 2, "progress", ""),
     itemName.PASWIM:        ItemData(1230784, 5, "progress", ""),
     itemName.PAEGGAIM:      ItemData(1230785, 4, "progress", ""),
+}
+
+progressive_ability_breakdown = {
+    itemName.PBBUST:        [itemName.BBUST, itemName.BDRILL],
+    itemName.PEGGS:         [itemName.FEGGS, itemName.GEGGS, itemName.IEGGS, itemName.CEGGS],
+    itemName.PSHOES:        [itemName.SSTRIDE, itemName.TTRAIN, itemName.SPRINGB, itemName.CLAWBTS],
+    itemName.PSWIM:         [itemName.DIVE, itemName.DAIR, itemName.FSWIM],
+    itemName.PBASH:         [itemName.GRAT, itemName.BBASH],
+    itemName.PFLIGHT:       [itemName.FPAD, itemName.BBOMB, itemName.AIREAIM],
+    itemName.PEGGAIM:       [itemName.EGGSHOOT, itemName.EGGAIM],
+    itemName.PASWIM:        [itemName.DIVE, itemName.AUQAIM, itemName.TTORP, itemName.DAIR, itemName.FSWIM],
+    itemName.PAEGGAIM:      [itemName.EGGSHOOT, itemName.AMAZEOGAZE, itemName.EGGAIM, itemName.BBLASTER],
 }
 
 level_progress_table = {


### PR DESCRIPTION
Massive cleanup to simplify a lot of logic:

* Traps / Big-O-Pants are no longer added to the pool during pool creation, instead, they are used to fill the rest of the item pool with items.
* Progressive Abilities are added in place of their respective abilities during generation (ex. Instead of adding FPAD, one instance of PFLIGHT is added instead)
* items that have a variable number of occurrences depending on options are added directly instead of going through item_filter