### PR TITLE
Rules.py Bugfixes & Additions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -47,6 +47,15 @@
     - Icy Side Train Station Egg Nest: Removed moves to dive underwater for hard tricks and glitch logics, as you can get the nest as it's bouncing.
     - Fire Side Train Station and the nest next to it: can be gotten with talon trot + flutter.
     - Glide Silo: checks to see if you have split up, on intended logic.
+    - GGM to WW: checks to see if you can smuggle talon trot on easy tricks and above.
+    - Plateau Jinjo: adds taxi pack as a way to clip through the boulder to get the jinjo on glitch logic.
+    - Spiral Mountain Pink Mystery Egg: adds egg aim + grenade eggs + clockwork eggs as a way to get the mystery egg on hard tricks and above.
+    - MT Jade Snake Grove Jinjo: adds golden goliath as a way to get the jinjo to glitch logic - just kick at the wall!
+    - Chuffy Wagon Signpost: from GGM, now accounts for being able to smuggle talon trot to get into the wagon.
+    - GGM Honeycomb near Prospector's Hut: adds egg barge as a way to clip through the boulder to get the honeycomb on glitch logic.
+    - WW Humba's Warp Pad: leg spring has been added to glitch logic and not just hard tricks.
+    - JRL Ancient Swimming Baths Cheato Page: wing whack has been added to glitch logic and not just hard tricks.
+    - HFP Mildred Jinjo: checks to see if you can jump up a small elevation on intended logic.
 
 # 4.4.2
   - Logic fixes:

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -4842,15 +4842,17 @@ class BanjoTooieRules:
     def glowbo_icy_side(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == LogicType.option_intended:
-            logic = self.long_jump(state)\
-                    or self.flap_flip(state) and self.grip_grab(state)
+            logic = self.hfp_top(state)\
+                    and (self.long_jump(state)\
+                    or self.flap_flip(state) and self.grip_grab(state))
         elif self.world.options.logic_type == LogicType.option_easy_tricks:
-            logic = self.long_jump(state)\
-                    or self.flap_flip(state) and self.grip_grab(state)
+            logic = self.hfp_top(state)\
+                    and (self.long_jump(state)\
+                    or self.flap_flip(state) and self.grip_grab(state))
         elif self.world.options.logic_type == LogicType.option_hard_tricks:
-            logic = True
+            logic = self.hfp_top(state)
         elif self.world.options.logic_type == LogicType.option_glitches:
-            logic = True
+            logic = self.hfp_top(state)
         return logic
 
     def ccl_glowbo_pool(self, state: CollectionState) -> bool:

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -2050,8 +2050,7 @@ class BanjoTooieRules:
                     and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state))
         elif self.world.options.logic_type == LogicType.option_easy_tricks:
             logic = self.humbaGI(state) and self.bill_drill(state)\
-                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state) \
-                    or self.egg_aim(state))
+                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state))
         elif self.world.options.logic_type == LogicType.option_hard_tricks:
             logic = self.humbaGI(state) and self.bill_drill(state)\
                     and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state))

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -2651,7 +2651,7 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == LogicType.option_hard_tricks:
             logic = self.bill_drill(state) or self.humbaGGM(state)
         elif self.world.options.logic_type == LogicType.option_glitches:
-            logic = self.bill_drill(state) or self.humbaGGM(state) or self.ground_rat_a_tat_rap(state)
+            logic = self.bill_drill(state) or self.humbaGGM(state) or self.ground_rat_a_tat_rap(state) or self.egg_barge(state)
         return logic
 
     def honeycomb_gm_station(self, state: CollectionState) -> bool:
@@ -3095,6 +3095,7 @@ class BanjoTooieRules:
                     (self.pack_whack(state) and self.grip_grab(state)))
         elif self.world.options.logic_type == LogicType.option_glitches:
             logic = self.talon_torpedo(state) and ((self.glide(state) and self.tall_jump(state)) or self.leg_spring(state) or
+                    self.wing_whack(state) or
                     (self.check_solo_moves(state, itemName.WWING) and self.tall_jump(state)) or
                     (self.tall_jump(state) and self.pack_whack(state) and self.grip_grab(state)))
         return logic
@@ -3909,7 +3910,7 @@ class BanjoTooieRules:
     def jinjo_mildred(self, state: CollectionState) -> bool:
         logic = True
         if self.world.options.logic_type == LogicType.option_intended:
-            logic = self.hfp_top(state) and (self.fire_eggs(state) or self.has_explosives(state) or \
+            logic = self.hfp_top(state) and self.small_elevation(state) and (self.fire_eggs(state) or self.has_explosives(state) or \
                     self.bill_drill(state) or self.dragon_kazooie(state))
         elif self.world.options.logic_type == LogicType.option_easy_tricks:
             logic = self.hfp_top(state) and (
@@ -6522,7 +6523,7 @@ class BanjoTooieRules:
                     or state.can_reach_region(regionName.IOHCT, self.player) and state.has(itemName.TRAINSWIH, self.player) and state.has(itemName.CHUFFY, self.player)
 
         elif self.world.options.logic_type == LogicType.option_easy_tricks:
-            logic = state.can_reach_region(regionName.GM, self.player) and (self.small_elevation(state) or self.beak_buster(state) or self.humbaGGM(state))\
+            logic = state.can_reach_region(regionName.GM, self.player) and (self.small_elevation(state) or self.beak_buster(state) or self.humbaGGM(state) or self.ggm_trot(state))\
                     or state.can_reach_region(regionName.WW, self.player) and state.has(itemName.TRAINSWWW, self.player) and state.has(itemName.CHUFFY, self.player)\
                     or state.can_reach_region(regionName.TL, self.player) and state.has(itemName.TRAINSWTD, self.player) and state.has(itemName.CHUFFY, self.player)\
                     or state.can_reach_region(regionName.GI1, self.player) and state.has(itemName.TRAINSWGI, self.player) and state.has(itemName.CHUFFY, self.player)\
@@ -6534,7 +6535,7 @@ class BanjoTooieRules:
                             or self.claw_clamber_boots(state)\
                             or self.flight_pad(state))
         elif self.world.options.logic_type == LogicType.option_hard_tricks:
-            logic = state.can_reach_region(regionName.GM, self.player) and (self.small_elevation(state) or self.beak_buster(state) or self.humbaGGM(state))\
+            logic = state.can_reach_region(regionName.GM, self.player) and (self.small_elevation(state) or self.beak_buster(state) or self.humbaGGM(state) or self.ggm_trot(state))\
                     or state.can_reach_region(regionName.WW, self.player) and state.has(itemName.TRAINSWWW, self.player) and state.has(itemName.CHUFFY, self.player)\
                     or state.can_reach_region(regionName.TL, self.player) and state.has(itemName.TRAINSWTD, self.player) and state.has(itemName.CHUFFY, self.player)\
                     or state.can_reach_region(regionName.GI1, self.player) and state.has(itemName.TRAINSWGI, self.player) and state.has(itemName.CHUFFY, self.player)\
@@ -6546,7 +6547,7 @@ class BanjoTooieRules:
                             or self.claw_clamber_boots(state)\
                             or self.flight_pad(state))
         elif self.world.options.logic_type == LogicType.option_glitches:
-            logic = state.can_reach_region(regionName.GM, self.player) and (self.small_elevation(state) or self.beak_buster(state) or self.humbaGGM(state))\
+            logic = state.can_reach_region(regionName.GM, self.player) and (self.small_elevation(state) or self.beak_buster(state) or self.humbaGGM(state) or self.ggm_trot(state))\
                     or state.can_reach_region(regionName.WW, self.player) and state.has(itemName.TRAINSWWW, self.player) and state.has(itemName.CHUFFY, self.player)\
                     or state.can_reach_region(regionName.TL, self.player) and state.has(itemName.TRAINSWTD, self.player) and state.has(itemName.CHUFFY, self.player)\
                     or state.can_reach_region(regionName.GI1, self.player) and state.has(itemName.TRAINSWGI, self.player) and state.has(itemName.CHUFFY, self.player)\
@@ -6827,6 +6828,7 @@ class BanjoTooieRules:
             logic = self.flap_flip(state) and self.grip_grab(state) \
                     or self.climb(state) and self.veryLongJump(state) and self.flap_flip(state)\
                     or self.clockwork_shot(state) and self.climb(state)\
+                    or self.leg_spring(state)\
                     or self.warp_to_ww_wumba(state)
         return logic
 

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -2047,16 +2047,19 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == LogicType.option_intended:
             logic = self.humbaGI(state) and self.bill_drill(state)\
-                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state))
+                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state))
         elif self.world.options.logic_type == LogicType.option_easy_tricks:
             logic = self.humbaGI(state) and self.bill_drill(state)\
-                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state))
+                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state) \
+                    or self.egg_aim(state))
         elif self.world.options.logic_type == LogicType.option_hard_tricks:
             logic = self.humbaGI(state) and self.bill_drill(state)\
-                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state))
+                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state) \
+                    or self.egg_aim(state))
         elif self.world.options.logic_type == LogicType.option_glitches:
             logic = self.humbaGI(state) and self.bill_drill(state)\
-                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state))
+                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state) \
+                    or self.egg_aim(state))
         return logic
     
     def skivvy_floor_2(self, state: CollectionState) -> bool:

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -1537,7 +1537,7 @@ class BanjoTooieRules:
 
         elif self.world.options.logic_type == LogicType.option_glitches:
             logic = self.mumboWW(state) and \
-                ((self.split_up(state) and self.spring_pad(state)) or self.leg_spring(state) or self.glide(state))
+                ((self.split_up(state) and self.spring_pad(state)) or self.leg_spring(state) or self.glide(state) or self.has_explosives(state))
         return logic
     
     def soggy(self, state: CollectionState) -> bool:

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -3463,10 +3463,12 @@ class BanjoTooieRules:
                     and self.flight_pad(state)
         elif self.world.options.logic_type == LogicType.option_hard_tricks:
             logic = (self.grenade_eggs(state) or (self.airborne_egg_aiming(state) and self.grenade_eggs_item(state))) \
-                    and self.flight_pad(state)
+                    and self.flight_pad(state) \
+                    or self.egg_aim(state) and self.grenade_eggs(state) and self.clockwork_shot(state)
         elif self.world.options.logic_type == LogicType.option_glitches:
             logic = (self.has_explosives(state) or (self.airborne_egg_aiming(state) and self.grenade_eggs_item(state))) \
-                    and self.flight_pad(state)
+                    and self.flight_pad(state) \
+                    or self.egg_aim(state) and self.grenade_eggs(state) and self.clockwork_shot(state)
         return logic
 
     def blue_mystery_egg(self, state: CollectionState) -> bool:
@@ -3494,7 +3496,7 @@ class BanjoTooieRules:
         elif self.world.options.logic_type == LogicType.option_hard_tricks:
             logic = self.bill_drill(state)
         elif self.world.options.logic_type == LogicType.option_glitches:
-            logic = self.bill_drill(state) or self.egg_barge(state)
+            logic = self.bill_drill(state) or self.egg_barge(state) or self.taxi_pack(state)
         return logic
 
     def jinjo_clifftop(self, state: CollectionState) -> bool:
@@ -3535,7 +3537,7 @@ class BanjoTooieRules:
                     self.clockwork_shot(state)
         elif self.world.options.logic_type == LogicType.option_glitches:
             logic = (self.flap_flip(state) and (self.beak_buster(state) or self.grip_grab(state))) or\
-                    self.clockwork_shot(state)
+                    self.clockwork_shot(state) or self.check_mumbo_magic(state, itemName.MUMBOMT)
         return logic
 
     def jinjo_stadium(self, state: CollectionState) -> bool:
@@ -7765,11 +7767,11 @@ class BanjoTooieRules:
         if self.world.options.logic_type == LogicType.option_intended:
             logic = self.backdoors_enabled(state) and self.small_elevation(state) and self.humbaGGM(state)
         elif self.world.options.logic_type == LogicType.option_easy_tricks:
-            logic = self.backdoors_enabled(state) and self.small_elevation(state) and self.humbaGGM(state)
+            logic = self.backdoors_enabled(state) and (self.small_elevation(state) or self.ggm_trot(state)) and self.humbaGGM(state)
         elif self.world.options.logic_type == LogicType.option_hard_tricks:
-            logic = self.backdoors_enabled(state) and self.small_elevation(state) and self.humbaGGM(state)
+            logic = self.backdoors_enabled(state) and (self.small_elevation(state) or self.ggm_trot(state)) and self.humbaGGM(state)
         elif self.world.options.logic_type == LogicType.option_glitches:
-            logic = (self.clockwork_eggs(state) or self.backdoors_enabled(state)) and self.small_elevation(state) and self.humbaGGM(state)
+            logic = (self.clockwork_eggs(state) or self.backdoors_enabled(state)) and (self.small_elevation(state) or self.ggm_trot(state)) and self.humbaGGM(state)
         return logic
 
     def ww_to_fuel_depot(self, state: CollectionState) -> bool:

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -2047,7 +2047,7 @@ class BanjoTooieRules:
         logic = True
         if self.world.options.logic_type == LogicType.option_intended:
             logic = self.humbaGI(state) and self.bill_drill(state)\
-                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state))
+                    and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state))
         elif self.world.options.logic_type == LogicType.option_easy_tricks:
             logic = self.humbaGI(state) and self.bill_drill(state)\
                     and state.can_reach_region(regionName.GIF, self.player) and (self.airborne_egg_aiming(state) or self.beak_bomb(state) \


### PR DESCRIPTION
- moggy glitch logic did not have mumbo + explosives as an option, despite that option being there for each other difficulty
- skivvy_floor_1 was in logic (on easy tricks only) if you had egg aim and that's it. assuming that was an error
- Icy side glowbo added new logic that didn't require intended or easy tricks to damage boost, however it removed checking to see if the player could get to the icy side (hfp_top)
- ggm_to_ww: only checks for small elevation, so I've added ggm_trot as an option for easy tricks and above
- jinjo_plateau: using taxi pack to clip into the boulder is doable, adding that to glitch logic
- pink_mystery_egg: flight isn't needed if you have egg aim, grenade eggs, and clockworks. added it to hard tricks and above since technically it's a clockwork shot to pick it up
- jinjo_jadesnakegrove: you can just kick it with the golden goliath; that has been added to glitch logic
- signpost_chuffy: you can reach chuffy's wagon by jumping from the chuffy sign with talon trot. since it's GGM, this means you can also smuggle trot for it. I've added this to easy tricks and above
- honeycomb_prospector: you can reach this with an egg barge, which I've added to glitch logic
- warp_pad_ww_wumba: leg spring was only considered on hard tricks, so I added it to glitch logic as well
- cheato_ancient_swimming_baths: wing whack was only considered on hard tricks, so I added it to glitch logic as well
- jinjo_mildred: intended logic didn't check for small_elevation, while all other logics did