### PR TITLE
Fix Guarded Jiggy & Dragon Brothers Jiggy

### DIFF
--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -2137,7 +2137,6 @@ class BanjoTooieRules:
             if self.world.options.randomize_boss_loading_zone:
                 logic = self.fire_eggs(state) and self.ice_eggs(state) and state.can_reach_region(regionName.HPIBOSS, self.player) and \
                         self.third_person_egg_shooting(state)\
-                        and self.claw_clamber_boots(state)\
                         and (self.tall_jump(state) or self.talon_trot(state))\
                         and (self.climb(state)\
                             or self.flap_flip(state)\
@@ -2164,7 +2163,6 @@ class BanjoTooieRules:
             if self.world.options.randomize_boss_loading_zone:
                 logic = self.fire_eggs(state) and self.ice_eggs(state) and state.can_reach_region(regionName.HPIBOSS, self.player) and \
                         self.third_person_egg_shooting(state)\
-                        and self.claw_clamber_boots(state)\
                         and (self.tall_jump(state) or self.talon_trot(state))\
                         and (self.climb(state)\
                             or self.flap_flip(state)\

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -2030,7 +2030,7 @@ class BanjoTooieRules:
                     and (self.spring_pad(state) or self.wing_whack(state) or self.glide(state))\
                     and (self.tall_jump(state) or self.leg_spring(state))
         elif self.world.options.logic_type == LogicType.option_easy_tricks:
-            logic = self.split_up(state) and\
+            logic = self.split_up(state) and (self.tall_jump(state) or self.leg_spring(state)) and\
                     ((self.claw_clamber_boots(state) or state.can_reach_region(regionName.GI2, self.player)) and self.spring_pad(state)\
                         or self.claw_clamber_boots(state) and (self.wing_whack(state) or self.glide(state)) and (self.egg_aim(state) or self.wing_whack(state))\
                         or self.leg_spring(state) and self.glide(state) and (self.egg_aim(state) or self.wing_whack(state)))\


### PR DESCRIPTION
- for Guarded Jiggy, easy tricks was missing a check for tall jump or leg spring
- for Dragon Brothers Jiggy, claw clambers were part of the randomized boss entrance logic on hard tricks and above, when they should only be on the non-randomized part of the if statements (I think?)