### PR TITLE
Move tall jump + beak buster to easy logic for nest_seaweed_bottom

### DIFF
--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -5432,7 +5432,8 @@ class BanjoTooieRules:
         if self.intended_logic(state):
             logic = self.flap_flip(state)
         elif self.easy_tricks_logic(state):
-            logic = self.flap_flip(state)
+            logic = self.flap_flip(state)\
+                    or self.tall_jump(state) and self.beak_buster(state)
         elif self.hard_tricks_logic(state):
             logic = self.flap_flip(state)\
                     or self.clockwork_shot(state)\


### PR DESCRIPTION
It's not precise, easy to replicate consistently, even when trying it for the first time. There are tons of beak busters like this in easy already (i.e. honeycomb_bovina, or the various ledges to get out of water). No reason to restrict this to hard.

https://github.com/user-attachments/assets/21e6f179-1428-44f4-adc2-9115d6362145

