### PR TITLE
Remove duplicated logic code for sack pack silo notes

### DIFF
--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -4754,27 +4754,15 @@ class BanjoTooieRules:
     def notes_ccl_silo(self, state: CollectionState) -> bool:
         logic = True
         if self.intended_logic(state):
-            logic = self.shack_pack(state) and (
-                        state.has(itemName.WARPCC1, self.player) and state.has(itemName.WARPCC2, self.player)\
-                        or self.can_use_floatus(state)
-                    )
+            logic = self.can_access_sack_pack_silo(state)
         elif self.easy_tricks_logic(state):
-            logic = self.shack_pack(state) and (
-                        state.has(itemName.WARPCC1, self.player) and state.has(itemName.WARPCC2, self.player)\
-                        or self.can_use_floatus(state)
-                    )\
+            logic = self.can_access_sack_pack_silo(state)\
                     or self.clockwork_eggs(state)
         elif self.hard_tricks_logic(state):
-            logic = self.shack_pack(state) and (
-                        state.has(itemName.WARPCC1, self.player) and state.has(itemName.WARPCC2, self.player)\
-                        or self.can_use_floatus(state)
-                    )\
+            logic = self.can_access_sack_pack_silo(state)\
                     or self.clockwork_eggs(state)
         elif self.glitches_logic(state):
-            logic = self.shack_pack(state) and (
-                        state.has(itemName.WARPCC1, self.player) and state.has(itemName.WARPCC2, self.player)\
-                        or self.can_use_floatus(state)
-                    )\
+            logic = self.can_access_sack_pack_silo(state)\
                     or self.clockwork_eggs(state)
         return logic
 


### PR DESCRIPTION
Just removes duplicate code. This is already done that way for the sign near the silo, so might as well do it for the notes.