### PR TITLE
Remove Nestsanity or signpost requirement Progressive Shoes

### DIFF
--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -631,10 +631,8 @@ class BanjoTooieWorld(World):
                 and not (
                     self.options.randomize_bk_moves
                     and self.options.randomize_bt_moves
-                    and (self.options.randomize_signposts or self.options.nestsanity)
                 ):
-            raise OptionError("You cannot have progressive Shoes without randomizing moves,\
-                randomizing BK moves and enabling either nestanity or randomize signpost")
+            raise OptionError("You cannot have progressive Shoes without randomizing moves and randomizing BK moves")
         if self.options.progressive_water_training != ProgressiveWaterTraining.option_none \
                 and (
                     self.options.randomize_bk_moves == RandomizeBKMoveList.option_none

--- a/worlds/banjo_tooie/test/test_progressive_moves.py
+++ b/worlds/banjo_tooie/test/test_progressive_moves.py
@@ -1,6 +1,6 @@
 from typing import Dict
 from ..Names import itemName
-from ..Options import EnableNestsanity, ProgressiveBashAttack, ProgressiveBeakBuster, \
+from ..Options import ProgressiveBashAttack, ProgressiveBeakBuster, \
     ProgressiveEggAim, ProgressiveFlight, ProgressiveShoes, ProgressiveWaterTraining, \
     RandomizeBKMoveList, RandomizeBTMoveList, RandomizeNotes, RandomizeStopnSwap
 from .test_logic import EasyTricksLogic, GlitchesLogic, HardTricksLogic, IntendedLogic
@@ -50,7 +50,6 @@ class TestProgressiveShoes(TestProgressiveMove):
     options = {
         **TestProgressiveMove.options,
         "progressive_shoes": ProgressiveShoes.option_true,
-        "nestsanity": EnableNestsanity.option_true
     }
     tested_items = {
         itemName.PSHOES: 4,
@@ -280,7 +279,6 @@ class TestTestProgressiveShoesIntended(TestProgressiveShoes, IntendedLogic):
     options = {
         **TestProgressiveShoes.options,
         **IntendedLogic.options,
-        "nestsanity": EnableNestsanity.option_true
 
     }
 
@@ -289,7 +287,6 @@ class TestTestProgressiveShoesEasyTricks(TestProgressiveShoes, EasyTricksLogic):
     options = {
         **TestProgressiveShoes.options,
         **EasyTricksLogic.options,
-        "nestsanity": EnableNestsanity.option_true
 
     }
 
@@ -298,8 +295,6 @@ class TestTestProgressiveShoesHardTricks(TestProgressiveShoes, HardTricksLogic):
     options = {
         **TestProgressiveShoes.options,
         **HardTricksLogic.options,
-        "nestsanity": EnableNestsanity.option_true
-
     }
 
 
@@ -307,8 +302,6 @@ class TestTestProgressiveShoesGlitches(TestProgressiveShoes, GlitchesLogic):
     options = {
         **TestProgressiveShoes.options,
         **GlitchesLogic.options,
-        "nestsanity": EnableNestsanity.option_true
-
     }
 
 


### PR DESCRIPTION
Updated generation logic to remove requirements for Nestsanity or Signposts for Progressive Shoes. It was not an existing requirement for Non Progressive Shoes. Locations are already satisfied by BK Moves requiring either notes, nests or signs except when player count = 1.

Removed test conditions for Nestsanity with Progressive Shoes which would cause generation errors.

Tested multiple generations with all logic types with no errors. No failures related to Progressive Shoes showed when running tests through pytest either